### PR TITLE
UX: freeze first column in submissions list; parse submission 'number of Units' data

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "migrate:rollback:all": "knex migrate:rollback --all",
     "migrate:rollback": "knex migrate:rollback",
     "migrate:up": "knex migrate:up",
-    "migrate": "knex migrate:latest --knexfile ./sbin/knexfile.js",
+    "migrate": "npm run migrate:latest",
     "postbuild:all": "npm run build",
     "postclean:all": "npm run clean",
     "postprisma:migrate:down": "npm run prisma:sync",

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "migrate:rollback:all": "knex migrate:rollback --all",
     "migrate:rollback": "knex migrate:rollback",
     "migrate:up": "knex migrate:up",
-    "migrate": "npm run migrate:latest",
+    "migrate": "knex migrate:latest --knexfile ./sbin/knexfile.js",
     "postbuild:all": "npm run build",
     "postclean:all": "npm run clean",
     "postprisma:migrate:down": "npm run prisma:sync",

--- a/app/src/services/chefs.ts
+++ b/app/src/services/chefs.ts
@@ -59,6 +59,18 @@ const service = {
           financiallySupportedHousingCoop: isTruthy(submission.isHousingCooperativeSupported)
         };
 
+        // get greatest of multiple Units data
+        const unitTypes = [submission.singleFamilyUnits, submission.multiFamilyUnits, submission.multiFamilyUnits1];
+        const maxUnits = unitTypes.reduce(
+          (ac, value) => {
+            // get max integer from value (eg: '1-49' returns 49)
+            const upperRange: number = value ? parseInt(value.toString().replace(/(.*)-/, '').trim()) : 0;
+            // compare with accumulator
+            return upperRange > ac.upperRange ? { value: value, upperRange: upperRange } : ac;
+          },
+          { upperRange: 0 } // initial value
+        ).value;
+
         await prisma.submission.create({
           data: {
             submissionId: response.submission.id,
@@ -74,7 +86,7 @@ const service = {
             naturalDisaster: submission.naturalDisasterInd,
             projectName: submission.companyNameRegistered,
             queuePriority: parseInt(submission.queuePriority),
-            singleFamilyUnits: submission.singleFamilyUnits ?? submission.multiFamilyUnits,
+            singleFamilyUnits: maxUnits,
             streetAddress: submission.streetAddress,
             submittedAt: response.submission.createdAt,
             submittedBy: response.submission.createdBy

--- a/frontend/src/assets/main.scss
+++ b/frontend/src/assets/main.scss
@@ -163,9 +163,6 @@ label {
 
 /* datatable */
 .p-datatable {
-  thead > tr > th {
-    background-color: transparent !important;
-  }
   &.p-datatable-striped tbody > tr {
     &:nth-child(even) {
       background-color: $app-table-stripe-background;
@@ -179,6 +176,9 @@ label {
       &:focus {
         outline: none !important;
       }
+    }
+    .p-frozen-column {
+      z-index: 1; // display over non-text elements (eg: checkboxes) in other columns
     }
   }
   .p-column-title {

--- a/frontend/src/components/submission/SubmissionForm.vue
+++ b/frontend/src/components/submission/SubmissionForm.vue
@@ -46,7 +46,7 @@ const initialFormValues: any = {
 
 // Form validation schema
 const formSchema = object({
-  applicationStatus: string().oneOf(ApplicationStatusList).label('Application Status'),
+  applicationStatus: string().oneOf(ApplicationStatusList).label('Activity state'),
   atsClientNumber: string()
     .when('addedToATS', {
       is: true,
@@ -56,7 +56,7 @@ const formSchema = object({
     .label('ATS Client Number'),
   confirmationId: string().required().label('Confirmation ID'),
   contactEmail: string().email().label('Contact Email'),
-  intakeStatus: string().oneOf(IntakeStatusList).label('Intake Status'),
+  intakeStatus: string().oneOf(IntakeStatusList).label('Intake state'),
   latitude: number().notRequired().min(48).max(60).label('Latitude'),
   longitude: number().notRequired().min(-139).max(-114).label('Longitude'),
   queuePriority: number()
@@ -329,7 +329,7 @@ const onSubmit = (values: any) => {
       <Dropdown
         class="col-4"
         name="intakeStatus"
-        label="Intake status"
+        label="Intake state"
         :disabled="!props.editable"
         :options="IntakeStatusList"
       />

--- a/frontend/src/views/SubmissionsView.vue
+++ b/frontend/src/views/SubmissionsView.vue
@@ -73,6 +73,7 @@ onMounted(async () => {
         field="confirmationId"
         header="Activity"
         :sortable="true"
+        frozen
       >
         <template #body="{ data }">
           <div :data-submissionId="data.submissionId">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3512

- Freeze the first column in the list view screen.
- When pulling the Units field from SHAS into our list view, review all 3 fields and choose the one with the largest number.
- Rename "Intake status" to "Intake state"

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->