### PR TITLE
Fix regex parsing housing unit numbers

### DIFF
--- a/app/src/controllers/submission.ts
+++ b/app/src/controllers/submission.ts
@@ -48,8 +48,18 @@ const controller = {
             const unitTypes = [data.singleFamilyUnits, data.multiFamilyUnits, data.multiFamilyUnits1];
             const maxUnits = unitTypes.reduce(
               (ac, value) => {
-                // Get max integer from value (eg: '1-49' returns 49)
-                const upperRange: number = value ? parseInt(value.toString().replace(/(.*)-/, '').trim()) : 0;
+                // Unit types are in the form of '1-49' or '>500'
+                // .match() with regex '/(\d+)(?!.*\d)/' matches the last number in a string, puts it in array.
+                // Get max integer from last element of array.
+                let upperRange: number = 0;
+                if (value) {
+                  upperRange = parseInt(
+                    value
+                      .toString()
+                      .match(/(\d+)(?!.*\d)/)
+                      ?.pop() ?? '0'
+                  );
+                }
                 // Compare with accumulator
                 return upperRange > ac.upperRange ? { value: value, upperRange: upperRange } : ac;
               },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Update a regex to cover edge cases when parsing for the largest number range 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->