### PR TITLE
Allow COMS objects to be attached to emails

### DIFF
--- a/app/src/controllers/roadmap.ts
+++ b/app/src/controllers/roadmap.ts
@@ -1,7 +1,7 @@
-import { emailService } from '../services';
+import { comsService, emailService } from '../services';
 
 import type { NextFunction, Request, Response } from '../interfaces/IExpress';
-import type { Email } from '../types';
+import type { Email, EmailAttachment } from '../types';
 
 const controller = {
   /**
@@ -9,11 +9,40 @@ const controller = {
    * Send an email with the roadmap data
    */
   send: async (
-    req: Request<never, never, { activityId: string; emailData: Email }>,
+    req: Request<
+      never,
+      never,
+      { activityId: string; attachmentIds: Array<{ filename: string; documentId: string }>; emailData: Email }
+    >,
     res: Response,
     next: NextFunction
   ) => {
     try {
+      if (req.body.attachmentIds) {
+        const attachments: Array<EmailAttachment> = [];
+
+        // Attempt to get the requested documents from COMS
+        // If succesful it is converted to base64 encoding and added to the attachment list
+        const uploadPromises = req.body.attachmentIds.map(async (x) => {
+          const { status, headers, data } = await comsService.getObject(req.headers, x.documentId);
+
+          if (status === 200) {
+            attachments.push({
+              content: Buffer.from(data).toString('base64'),
+              contentType: headers['content-type'],
+              encoding: 'base64',
+              filename: x.filename
+            });
+          }
+        });
+
+        await Promise.all(uploadPromises);
+
+        // All succesful so attachment list is added to payload
+        req.body.emailData.attachments = attachments;
+      }
+
+      // Send the email
       const { data, status } = await emailService.email(req.body.emailData);
       res.status(status).json(data);
     } catch (e: unknown) {

--- a/app/src/services/coms.ts
+++ b/app/src/services/coms.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import config from 'config';
-import { IncomingHttpHeaders } from 'http';
 
 import type { AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { IncomingHttpHeaders } from 'http';
 
 /**
  * @function comsAxios
@@ -25,10 +25,28 @@ const service = {
   /**
    * @function getObject
    * Get an object
+   * @param {IncomingHttpHeaders} incomingHeaders The request headers
    * @param {string} objectId The id for the object to get
    */
-  getObject(headers: IncomingHttpHeaders, objectId: string) {
-    return comsAxios({ responseType: 'arraybuffer', headers }).get(`/object/${objectId}`);
+  async getObject(incomingHeaders: IncomingHttpHeaders, objectId: string) {
+    const { status, headers, data } = await comsAxios({ responseType: 'arraybuffer', headers: incomingHeaders }).get(
+      `/object/${objectId}`
+    );
+    return { status, headers, data };
+  },
+
+  /**
+   * @function getObjects
+   * Gets a list of objects
+   * @param {IncomingHttpHeaders} incomingHeaders The request headers
+   * @param {string[]} objectIds Array of object ids to get
+   */
+  async getObjects(incomingHeaders: IncomingHttpHeaders, objectIds: Array<string>) {
+    const { data } = await comsAxios({ headers: incomingHeaders }).get('/object', {
+      params: { objectId: objectIds }
+    });
+
+    return data;
   }
 };
 

--- a/app/src/services/coms.ts
+++ b/app/src/services/coms.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import config from 'config';
+import { IncomingHttpHeaders } from 'http';
+
+import type { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+/**
+ * @function comsAxios
+ * Returns an Axios instance for the COMS API
+ * @param {AxiosRequestConfig} options Axios request config options
+ * @returns {AxiosInstance} An axios instance
+ */
+function comsAxios(options: AxiosRequestConfig = {}): AxiosInstance {
+  // Create axios instance
+  const instance = axios.create({
+    baseURL: config.get('frontend.coms.apiPath'),
+    timeout: 10000,
+    ...options
+  });
+
+  return instance;
+}
+
+const service = {
+  /**
+   * @function getObject
+   * Get an object
+   * @param {string} objectId The id for the object to get
+   */
+  getObject(headers: IncomingHttpHeaders, objectId: string) {
+    return comsAxios({ responseType: 'arraybuffer', headers }).get(`/object/${objectId}`);
+  }
+};
+
+export default service;

--- a/app/src/services/index.ts
+++ b/app/src/services/index.ts
@@ -1,6 +1,7 @@
-export { default as submissionService } from './submission';
+export { default as comsService } from './coms';
 export { default as documentService } from './document';
 export { default as emailService } from './email';
 export { default as noteService } from './note';
 export { default as permitService } from './permit';
+export { default as submissionService } from './submission';
 export { default as userService } from './user';

--- a/app/src/types/Email.ts
+++ b/app/src/types/Email.ts
@@ -1,14 +1,16 @@
+import { EmailAttachment } from './EmailAttachment';
+
 export type Email = {
-  bcc: Array<string> | undefined;
+  bcc?: Array<string>;
   bodyType: string;
   body: string;
-  cc: Array<string> | undefined;
-  delayTS: number | undefined;
-  encoding: string | undefined;
+  cc?: Array<string>;
+  delayTS?: number;
+  encoding?: string;
   from: string;
-  priority: string | undefined;
+  priority?: string;
   subject: string;
   to: Array<string>;
-  tag: string | undefined;
-  attachments: Array<string> | undefined;
+  tag?: string;
+  attachments?: Array<EmailAttachment>;
 };

--- a/app/src/types/EmailAttachment.ts
+++ b/app/src/types/EmailAttachment.ts
@@ -1,0 +1,6 @@
+export type EmailAttachment = {
+  content: string;
+  contentType: string;
+  encoding: string;
+  filename: string;
+};

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -3,6 +3,7 @@ export type { ChefsSubmissionExport } from './ChefsSubmissionExport';
 export type { CurrentUser } from './CurrentUser';
 export type { Document } from './Document';
 export type { Email } from './Email';
+export type { EmailAttachment } from './EmailAttachment';
 export type { IdentityProvider } from './IdentityProvider';
 export type { Note } from './Note';
 export type { Permit } from './Permit';

--- a/app/src/validators/roadmap.ts
+++ b/app/src/validators/roadmap.ts
@@ -7,13 +7,8 @@ const schema = {
   send: {
     body: Joi.object({
       activityId: activityId,
+      selectedFileIds: Joi.array().items(Joi.string()),
       emailData: Joi.object().keys({
-        // attachments: Joi.object().keys({
-        //   content: Joi.string().required(),
-        //   contentType: Joi.string(),
-        //   encoding: Joi.string(),
-        //   filename: Joi.string().required(),
-        // }),
         bcc: Joi.array().items(emailJoi),
         bodyType: Joi.string().required(),
         body: Joi.string().required(),

--- a/app/tests/unit/controllers/roadmap.spec.ts
+++ b/app/tests/unit/controllers/roadmap.spec.ts
@@ -1,0 +1,253 @@
+import { roadmapController } from '../../../src/controllers';
+import { comsService, emailService } from '../../../src/services';
+
+// Mock config library - @see {@link https://stackoverflow.com/a/64819698}
+jest.mock('config');
+
+const mockResponse = () => {
+  const res: { status?: jest.Mock; json?: jest.Mock; end?: jest.Mock } = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+
+  return res;
+};
+
+let res = mockResponse();
+beforeEach(() => {
+  res = mockResponse();
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+const CURRENT_USER = { authType: 'BEARER', tokenPayload: null };
+
+describe('send', () => {
+  const next = jest.fn();
+
+  // Mock service calls
+  const getObjectSpy = jest.spyOn(comsService, 'getObject');
+  const getObjectsSpy = jest.spyOn(comsService, 'getObjects');
+  const emailSpy = jest.spyOn(emailService, 'email');
+
+  it('should return 200 if all good', async () => {
+    const req = {
+      body: {
+        activityId: '123-123',
+        emailData: {
+          body: 'Some message text',
+          bodyType: 'text',
+          from: 'test@gov.bc.ca',
+          to: 'hello@gov.bc.ca',
+          subject: 'Unit tests'
+        }
+      },
+      currentUser: CURRENT_USER
+    };
+
+    const emailResponse = {
+      data: 'foo',
+      status: 200
+    };
+
+    emailSpy.mockResolvedValue(emailResponse);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await roadmapController.send(req as any, res as any, next);
+
+    expect(getObjectsSpy).toHaveBeenCalledTimes(0);
+    expect(getObjectSpy).toHaveBeenCalledTimes(0);
+    expect(emailSpy).toHaveBeenCalledTimes(1);
+    expect(emailSpy).toHaveBeenCalledWith(req.body.emailData);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(emailResponse.data);
+  });
+
+  it('should get coms objects and attach', async () => {
+    const req = {
+      body: {
+        activityId: '123-123',
+        selectedFileIds: ['123', '456'],
+        emailData: {
+          body: 'Some message text',
+          bodyType: 'text',
+          from: 'test@gov.bc.ca',
+          to: 'hello@gov.bc.ca',
+          subject: 'Unit tests',
+          attachments: [
+            {
+              content: Buffer.from('foo').toString('base64'),
+              contentType: 'filetype',
+              encoding: 'base64',
+              filename: 'foo'
+            },
+            {
+              content: Buffer.from('foo').toString('base64'),
+              contentType: 'filetype',
+              encoding: 'base64',
+              filename: 'bar'
+            }
+          ]
+        }
+      },
+      currentUser: CURRENT_USER,
+      headers: {
+        authorization: '89sdfiuw4'
+      }
+    };
+
+    const getObjectsResponse = [
+      { id: '123', name: 'foo' },
+      { id: '456', name: 'bar' }
+    ];
+
+    const getObjectResponse = {
+      data: 'foo',
+      headers: {
+        'content-type': 'filetype'
+      },
+      status: 200
+    };
+
+    const emailResponse = {
+      data: 'foo',
+      status: 200
+    };
+
+    getObjectsSpy.mockResolvedValue(getObjectsResponse);
+    getObjectSpy.mockResolvedValue(getObjectResponse);
+    emailSpy.mockResolvedValue(emailResponse);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await roadmapController.send(req as any, res as any, next);
+
+    expect(getObjectsSpy).toHaveBeenCalledTimes(1);
+    expect(getObjectsSpy).toHaveBeenNthCalledWith(1, req.headers, req.body.selectedFileIds);
+    expect(getObjectSpy).toHaveBeenCalledTimes(2);
+    expect(getObjectSpy).toHaveBeenNthCalledWith(1, req.headers, req.body.selectedFileIds[0]);
+    expect(getObjectSpy).toHaveBeenNthCalledWith(2, req.headers, req.body.selectedFileIds[1]);
+    expect(emailSpy).toHaveBeenCalledTimes(1);
+    expect(emailSpy).toHaveBeenCalledWith(req.body.emailData);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(emailResponse.data);
+  });
+
+  it('should call next if COMS fails', async () => {
+    const req = {
+      body: {
+        activityId: '123-123',
+        selectedFileIds: ['123', '456'],
+        emailData: {
+          body: 'Some message text',
+          bodyType: 'text',
+          from: 'test@gov.bc.ca',
+          to: 'hello@gov.bc.ca',
+          subject: 'Unit tests',
+          attachments: [
+            {
+              content: Buffer.from('foo').toString('base64'),
+              contentType: 'filetype',
+              encoding: 'base64',
+              filename: 'foo'
+            },
+            {
+              content: Buffer.from('foo').toString('base64'),
+              contentType: 'filetype',
+              encoding: 'base64',
+              filename: 'bar'
+            }
+          ]
+        }
+      },
+      currentUser: CURRENT_USER,
+      headers: {
+        authorization: '89sdfiuw4'
+      }
+    };
+
+    const getObjectsResponse = [
+      { id: '123', name: 'foo' },
+      { id: 'nonmatchingid', name: 'bar' }
+    ];
+
+    getObjectsSpy.mockResolvedValue(getObjectsResponse);
+    getObjectSpy.mockImplementationOnce(() => {
+      throw new Error();
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await roadmapController.send(req as any, res as any, next);
+
+    expect(getObjectsSpy).toHaveBeenCalledTimes(1);
+    expect(getObjectsSpy).toHaveBeenNthCalledWith(1, req.headers, req.body.selectedFileIds);
+    expect(getObjectSpy).toHaveBeenCalledTimes(2);
+    expect(getObjectSpy).toHaveBeenNthCalledWith(1, req.headers, req.body.selectedFileIds[0]);
+    expect(getObjectSpy).toHaveBeenNthCalledWith(2, req.headers, req.body.selectedFileIds[1]);
+    expect(emailSpy).toHaveBeenCalledTimes(0);
+    expect(res.status).toHaveBeenCalledTimes(0);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call next if a filename is not found', async () => {
+    const req = {
+      body: {
+        activityId: '123-123',
+        selectedFileIds: ['123', '456'],
+        emailData: {
+          body: 'Some message text',
+          bodyType: 'text',
+          from: 'test@gov.bc.ca',
+          to: 'hello@gov.bc.ca',
+          subject: 'Unit tests',
+          attachments: [
+            {
+              content: Buffer.from('foo').toString('base64'),
+              contentType: 'filetype',
+              encoding: 'base64',
+              filename: 'foo'
+            },
+            {
+              content: Buffer.from('foo').toString('base64'),
+              contentType: 'filetype',
+              encoding: 'base64',
+              filename: 'bar'
+            }
+          ]
+        }
+      },
+      currentUser: CURRENT_USER,
+      headers: {
+        authorization: '89sdfiuw4'
+      }
+    };
+
+    const getObjectsResponse = [
+      { id: '123', name: 'foo' },
+      { id: 'nonmatchingid', name: 'bar' }
+    ];
+
+    const getObjectResponse = {
+      data: 'foo',
+      headers: {
+        'content-type': 'filetype'
+      },
+      status: 200
+    };
+
+    getObjectsSpy.mockResolvedValue(getObjectsResponse);
+    getObjectSpy.mockResolvedValue(getObjectResponse);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await roadmapController.send(req as any, res as any, next);
+
+    expect(getObjectsSpy).toHaveBeenCalledTimes(1);
+    expect(getObjectsSpy).toHaveBeenNthCalledWith(1, req.headers, req.body.selectedFileIds);
+    expect(getObjectSpy).toHaveBeenCalledTimes(2);
+    expect(getObjectSpy).toHaveBeenNthCalledWith(1, req.headers, req.body.selectedFileIds[0]);
+    expect(getObjectSpy).toHaveBeenNthCalledWith(2, req.headers, req.body.selectedFileIds[1]);
+    expect(emailSpy).toHaveBeenCalledTimes(0);
+    expect(res.status).toHaveBeenCalledTimes(0);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/file/DocumentCard.vue
+++ b/frontend/src/components/file/DocumentCard.vue
@@ -140,12 +140,6 @@ function onClick() {
       >
         <font-awesome-icon icon="fa-solid fa-trash" />
       </Button>
-      <Button
-        v-if="false"
-        class="p-button-lg p-button-text p-0"
-      >
-        <font-awesome-icon icon="fa-solid fa-check" />
-      </Button>
     </template>
   </Card>
 </template>

--- a/frontend/src/components/file/DocumentCard.vue
+++ b/frontend/src/components/file/DocumentCard.vue
@@ -96,7 +96,11 @@ function onClick() {
 </script>
 
 <template>
-  <Card class="pb-1 text-center">
+  <Card
+    class="pb-1 text-center"
+    :class="{ clicked: isSelected }"
+    @click="onClick"
+  >
     <template #header>
       <img
         alt="document header"
@@ -105,17 +109,14 @@ function onClick() {
       />
     </template>
     <template #content>
-      <div
-        class="grid"
-        @click="onClick"
-      >
-        <h4
+      <div class="grid">
+        <div
           v-tooltip.bottom="props.document.filename"
-          class="col-12 mb-0 text-left"
-          style="text-overflow: ellipsis; overflow: hidden"
+          class="col-12 mb-0 text-left font-semibold text-overflow-ellipsis white-space-nowrap"
+          style="overflow: hidden"
         >
           {{ props.document.filename }}
-        </h4>
+        </div>
         <h6 class="col-8 text-left mt-0 mb-0">
           {{ formatDateLong(props.document.createdAt as string) }}
         </h6>
@@ -139,7 +140,10 @@ function onClick() {
       >
         <font-awesome-icon icon="fa-solid fa-trash" />
       </Button>
-      <Button v-if="selectable && isSelected">
+      <Button
+        v-if="false"
+        class="p-button-lg p-button-text p-0"
+      >
         <font-awesome-icon icon="fa-solid fa-check" />
       </Button>
     </template>
@@ -152,6 +156,10 @@ function onClick() {
   position: relative;
   top: 50%;
   transform: translateY(-50%);
+}
+
+.clicked {
+  box-shadow: 0 0 11px rgb(83, 186, 15);
 }
 
 :deep(.p-card-header) {

--- a/frontend/src/components/file/DocumentCard.vue
+++ b/frontend/src/components/file/DocumentCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { filesize } from 'filesize';
+import { ref } from 'vue';
 
 import { Button, Card, useConfirm, useToast } from '@/lib/primevue';
 import { documentService } from '@/services';
@@ -16,20 +17,28 @@ import pdf from '@/assets/images/pdf.svg';
 import shape from '@/assets/images/shape.svg';
 import spreadsheet from '@/assets/images/spreadsheet.svg';
 
+import type { Ref } from 'vue';
 import type { Document } from '@/types';
 
 // Props
 type Props = {
   document: Document;
   deleteButton?: boolean;
+  selectable?: boolean;
+  selected?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
-  deleteButton: true
+  deleteButton: true,
+  selectable: false,
+  selected: false
 });
 
 // Emits
-const emit = defineEmits(['document:deleted']);
+const emit = defineEmits(['document:clicked', 'document:deleted']);
+
+// State
+const isSelected: Ref<boolean> = ref(props.selected);
 
 // Actions
 const confirm = useConfirm();
@@ -77,6 +86,13 @@ const displayIcon = (mimeType = '') => {
       return file;
   }
 };
+
+function onClick() {
+  if (props.selectable) {
+    isSelected.value = !isSelected.value;
+    emit('document:clicked', { document: props.document, selected: isSelected.value });
+  }
+}
 </script>
 
 <template>
@@ -89,7 +105,10 @@ const displayIcon = (mimeType = '') => {
       />
     </template>
     <template #content>
-      <div class="grid">
+      <div
+        class="grid"
+        @click="onClick"
+      >
         <h4
           v-tooltip.bottom="props.document.filename"
           class="col-12 mb-0 text-left"
@@ -119,6 +138,9 @@ const displayIcon = (mimeType = '') => {
         "
       >
         <font-awesome-icon icon="fa-solid fa-trash" />
+      </Button>
+      <Button v-if="selectable && isSelected">
+        <font-awesome-icon icon="fa-solid fa-check" />
       </Button>
     </template>
   </Card>

--- a/frontend/src/components/file/FileSelectModal.vue
+++ b/frontend/src/components/file/FileSelectModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed } from 'vue';
 import DocumentCard from '@/components/file/DocumentCard.vue';
 import { Button, Dialog } from '@/lib/primevue';
 
@@ -9,29 +9,33 @@ import type { Document } from '@/types';
 // Props
 type Props = {
   documents: Array<Document>;
+  selectedDocuments?: Array<Document>;
 };
 
-const props = withDefaults(defineProps<Props>(), {});
+const props = withDefaults(defineProps<Props>(), {
+  selectedDocuments: () => []
+});
 
 // Emits
 const emit = defineEmits(['fileSelect:submit']);
 
 // State
-const selectedFiles: Ref<Array<Document>> = ref([]);
 const visible = defineModel<boolean>('visible');
+const selectedFiles: Ref<Array<Document>> = computed(() => props.selectedDocuments);
 
 // Actions
-function onDocumentClicked(data: any) {
+function onDocumentClicked(data: { document: Document; selected: boolean }) {
   if (data.selected) {
-    if (!selectedFiles.value.find((x) => x === data.document.documentId)) selectedFiles.value.push(data.document);
+    if (!selectedFiles.value.includes(data.document)) {
+      selectedFiles.value.push(data.document);
+    }
   } else {
     selectedFiles.value = selectedFiles.value.filter((x) => x.documentId !== data.document.documentId);
   }
 }
 
 function onSave() {
-  emit('fileSelect:submit', selectedFiles.value);
-  selectedFiles.value = [];
+  emit('fileSelect:submit', selectedFiles.value.slice());
   visible.value = false;
 }
 </script>
@@ -49,7 +53,7 @@ function onSave() {
     <div class="col-12">
       <div class="grid">
         <div
-          v-for="(document, index) in documents"
+          v-for="(document, index) in props.documents"
           :key="document.documentId"
           :index="index"
           class="col-12 md:col-6 lg:col-4 xl:col-3"

--- a/frontend/src/components/file/FileSelectModal.vue
+++ b/frontend/src/components/file/FileSelectModal.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import DocumentCard from '@/components/file/DocumentCard.vue';
+import { Button, Dialog } from '@/lib/primevue';
+
+import type { Ref } from 'vue';
+import type { Document } from '@/types';
+
+// Props
+type Props = {
+  documents: Array<Document>;
+};
+
+const props = withDefaults(defineProps<Props>(), {});
+
+// Emits
+const emit = defineEmits(['fileSelect:submit']);
+
+// State
+const selectedFiles: Ref<Array<Document>> = ref([]);
+const visible = defineModel<boolean>('visible');
+
+// Actions
+function onDocumentClicked(data: any) {
+  if (data.selected) {
+    if (!selectedFiles.value.find((x) => x === data.document.documentId)) selectedFiles.value.push(data.document);
+  } else {
+    selectedFiles.value = selectedFiles.value.filter((x) => x.documentId !== data.document.documentId);
+  }
+}
+
+function onSave() {
+  emit('fileSelect:submit', selectedFiles.value);
+  selectedFiles.value = [];
+  visible.value = false;
+}
+</script>
+
+<template>
+  <Dialog
+    v-model:visible="visible"
+    :draggable="false"
+    :modal="true"
+    class="app-info-dialog w-6"
+  >
+    <template #header>
+      <span class="p-dialog-title">Select files</span>
+    </template>
+    <div class="col-12">
+      <div class="grid">
+        <div
+          v-for="(document, index) in documents"
+          :key="document.documentId"
+          :index="index"
+          class="col-12 md:col-6 lg:col-4 xl:col-3"
+        >
+          <DocumentCard
+            :document="document"
+            class="hover-hand hover-shadow"
+            :delete-button="false"
+            :selectable="true"
+            :selected="selectedFiles.includes(document)"
+            @document:clicked="onDocumentClicked"
+          />
+        </div>
+      </div>
+      <div class="field col-12 flex">
+        <div class="flex-auto">
+          <Button
+            class="mr-2"
+            label="Save"
+            icon="pi pi-check"
+            @click="onSave"
+          />
+          <Button
+            class="p-button-outlined mr-2"
+            label="Cancel"
+            icon="pi pi-times"
+            @click="visible = false"
+          />
+        </div>
+      </div>
+    </div>
+  </Dialog>
+</template>

--- a/frontend/src/components/file/FileSelectModal.vue
+++ b/frontend/src/components/file/FileSelectModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { ref, watchEffect } from 'vue';
+
 import DocumentCard from '@/components/file/DocumentCard.vue';
 import { Button, Dialog } from '@/lib/primevue';
 
@@ -21,7 +22,7 @@ const emit = defineEmits(['fileSelect:submit']);
 
 // State
 const visible = defineModel<boolean>('visible');
-const selectedFiles: Ref<Array<Document>> = computed(() => props.selectedDocuments);
+const selectedFiles: Ref<Array<Document>> = ref(props.selectedDocuments);
 
 // Actions
 function onDocumentClicked(data: { document: Document; selected: boolean }) {
@@ -38,6 +39,10 @@ function onSave() {
   emit('fileSelect:submit', selectedFiles.value.slice());
   visible.value = false;
 }
+
+watchEffect(() => {
+  selectedFiles.value = props.selectedDocuments;
+});
 </script>
 
 <template>

--- a/frontend/src/components/roadmap/Roadmap.vue
+++ b/frontend/src/components/roadmap/Roadmap.vue
@@ -85,7 +85,7 @@ function onFileRemove(document: Document) {
   selectedFiles.value = selectedFiles.value.filter((x) => x.documentId !== document.documentId);
 }
 
-function onFileSelect(data: any) {
+function onFileSelect(data: Array<Document>) {
   selectedFiles.value = data;
   formRef.value?.setFieldValue(
     'attachments',
@@ -113,7 +113,7 @@ onMounted(async () => {
 
   // Initial form values
   initialFormValues.value = {
-    // from: navigator.email,
+    from: navigator.email,
     to: props.submission.contactEmail,
     cc: undefined,
     bcc: bcc,
@@ -215,6 +215,7 @@ onMounted(async () => {
   <FileSelectModal
     v-model:visible="fileSelectModalVisible"
     :documents="documents"
+    :selected-documents="selectedFiles.slice()"
     @file-select:submit="onFileSelect"
   />
 </template>

--- a/frontend/src/components/roadmap/Roadmap.vue
+++ b/frontend/src/components/roadmap/Roadmap.vue
@@ -3,6 +3,7 @@ import { Form } from 'vee-validate';
 import { onMounted, ref } from 'vue';
 import { array, object, string } from 'yup';
 
+import FileSelectModal from '@/components/file/FileSelectModal.vue';
 import { InputText, TextArea } from '@/components/form';
 import { Button, useConfirm, useToast } from '@/lib/primevue';
 import { roadmapService, userService } from '@/services';
@@ -11,12 +12,13 @@ import { PERMIT_STATUS } from '@/utils/enums';
 import { roadmapTemplate } from '@/utils/templates';
 
 import type { Ref } from 'vue';
-import type { Permit, PermitType, Submission } from '@/types';
+import type { Document, Permit, PermitType, Submission } from '@/types';
 import { storeToRefs } from 'pinia';
 
 // Props
 type Props = {
   activityId: string;
+  documents: Array<Document>;
   permits: Array<Permit>;
   permitTypes: Array<PermitType>;
   submission: Submission;
@@ -28,7 +30,10 @@ const props = withDefaults(defineProps<Props>(), {});
 const { getConfig } = storeToRefs(useConfigStore());
 
 // State
+const fileSelectModalVisible: Ref<boolean> = ref(false);
+const formRef: Ref<InstanceType<typeof Form> | null> = ref(null);
 const initialFormValues: Ref<any> = ref();
+const selectedFiles: Ref<Array<Document>> = ref([]);
 
 // Form schema
 const emailValidator = array()
@@ -76,6 +81,18 @@ function getPermitTypeNamesByStatus(permits: Array<Permit>, permitTypes: Array<P
     .map((name) => name as string);
 }
 
+function onFileRemove(document: Document) {
+  selectedFiles.value = selectedFiles.value.filter((x) => x.documentId !== document.documentId);
+}
+
+function onFileSelect(data: any) {
+  selectedFiles.value = data;
+  formRef.value?.setFieldValue(
+    'attachments',
+    data.map((x: Document) => ({ filename: x.filename, documentId: x.documentId }))
+  );
+}
+
 onMounted(async () => {
   // get navigator details
   const configBCC = getConfig.value.ches?.bcc;
@@ -121,6 +138,7 @@ onMounted(async () => {
 <template>
   <Form
     v-if="initialFormValues"
+    ref="formRef"
     :initial-values="initialFormValues"
     :validation-schema="formSchema"
     @submit="confirmSubmit"
@@ -158,13 +176,31 @@ onMounted(async () => {
       />
       <div class="col-12"><label class="font-bold">Add attachments</label></div>
       <div class="col-12 pt-2">
-        <Button>
+        <Button @click="fileSelectModalVisible = true">
           <font-awesome-icon
             icon="fa-solid fa-plus"
             class="mr-1"
           />
           Choose
         </Button>
+        <div
+          v-for="(document, index) in selectedFiles"
+          :key="document.documentId"
+          :index="index"
+          class="mt-1"
+        >
+          <div class="flex align-items-center">
+            <div>
+              <Button
+                class="p-button-sm p-button-outlined p-button-danger p-1 mr-1"
+                @click="onFileRemove(document)"
+              >
+                <font-awesome-icon icon="fa-solid fa-times" />
+              </Button>
+            </div>
+            <div>{{ document.filename }}</div>
+          </div>
+        </div>
       </div>
       <div class="col-12 pt-5">
         <Button
@@ -175,4 +211,10 @@ onMounted(async () => {
       </div>
     </div>
   </Form>
+
+  <FileSelectModal
+    v-model:visible="fileSelectModalVisible"
+    :documents="documents"
+    @file-select:submit="onFileSelect"
+  />
 </template>

--- a/frontend/src/components/roadmap/Roadmap.vue
+++ b/frontend/src/components/roadmap/Roadmap.vue
@@ -65,7 +65,11 @@ const confirmSubmit = (data: any) => {
     rejectLabel: 'Cancel',
     accept: async () => {
       try {
-        await roadmapService.send(props.activityId, data);
+        await roadmapService.send(
+          props.activityId,
+          selectedFiles.value.map((x: Document) => x.documentId),
+          data
+        );
         toast.success('Roadmap sent');
       } catch (e: any) {
         toast.error('Failed to send roadmap', e.response.data);
@@ -87,27 +91,24 @@ function onFileRemove(document: Document) {
 
 function onFileSelect(data: Array<Document>) {
   selectedFiles.value = data;
-  formRef.value?.setFieldValue(
-    'attachments',
-    data.map((x: Document) => ({ filename: x.filename, documentId: x.documentId }))
-  );
 }
 
 onMounted(async () => {
-  // get navigator details
+  // Get navigator details
   const configBCC = getConfig.value.ches?.bcc;
   let bcc = configBCC;
   let navigator = {
-    email: configBCC,
+    email: configBCC ?? '',
     fullName: 'Permit Connect Navigator Service'
   };
+
   if (props.submission.assignedUserId) {
     const assignee = (await userService.searchUsers({ userId: [props.submission.assignedUserId] })).data[0];
 
     if (assignee) {
       navigator = assignee;
       navigator.fullName = `${assignee.firstName} ${assignee.lastName}`;
-      bcc = `${bcc}, ${assignee.email}`;
+      bcc = (bcc ? `${bcc}, ` : '') + assignee.email;
     }
   }
 

--- a/frontend/src/services/roadmapService.ts
+++ b/frontend/src/services/roadmapService.ts
@@ -2,13 +2,15 @@ import { appAxios } from './interceptors';
 
 import { parseCSV } from '@/utils/utils';
 
+import type { Email } from '@/types';
+
 export default {
   /**
    * @function send
    * Send an email with the roadmap data
    * @returns {Promise} An axios response
    */
-  send(activityId: string, emailData: any) {
+  send(activityId: string, selectedFileIds: Array<string>, emailData: Email) {
     if (emailData.to && !Array.isArray(emailData.to)) {
       emailData.to = parseCSV(emailData.to);
     }
@@ -19,9 +21,6 @@ export default {
       emailData.bcc = parseCSV(emailData.bcc);
     }
 
-    const attachmentIds = emailData.attachments;
-    delete emailData.attachments;
-
-    return appAxios().put('roadmap', { activityId, attachmentIds, emailData });
+    return appAxios().put('roadmap', { activityId, selectedFileIds, emailData });
   }
 };

--- a/frontend/src/services/roadmapService.ts
+++ b/frontend/src/services/roadmapService.ts
@@ -19,6 +19,9 @@ export default {
       emailData.bcc = parseCSV(emailData.bcc);
     }
 
-    return appAxios().put('roadmap', { activityId, emailData });
+    const attachmentIds = emailData.attachments;
+    delete emailData.attachments;
+
+    return appAxios().put('roadmap', { activityId, attachmentIds, emailData });
   }
 };

--- a/frontend/src/types/Email.ts
+++ b/frontend/src/types/Email.ts
@@ -1,0 +1,13 @@
+export type Email = {
+  bcc?: Array<string>;
+  bodyType: string;
+  body: string;
+  cc?: Array<string>;
+  delayTS?: number;
+  encoding?: string;
+  from: string;
+  priority?: string;
+  subject: string;
+  to: Array<string>;
+  tag?: string;
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,4 +1,5 @@
 export type { Document } from './Document';
+export type { Email } from './Email';
 export type { IdentityProvider } from './IdentityProvider';
 export type { Note } from './Note';
 export type { Permit } from './Permit';

--- a/frontend/src/views/SubmissionView.vue
+++ b/frontend/src/views/SubmissionView.vue
@@ -233,6 +233,7 @@ onMounted(async () => {
       <Roadmap
         v-if="!loading"
         :activity-id="activityId"
+        :documents="documents"
         :permits="permits"
         :permit-types="permitTypes"
         :submission="submission as Submission"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Allows for any documents that have been added to the submission to be selected in a modal and attached to the email.

baed69f Only send document ID for attachments. Back end controller unit tests.
1dba864 View and modal correctly tracking selected files
1cb56e3 Allow COMS objects to be attached to emails

[SHOWCASE-3596](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3596)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->