### PR TITLE
Roadmap email body templating

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These users will be the default owners for everything in the repo.
 # Unless a later match takes precedence, the following users will be
 # requested for review when someone opens a pull request.
-* @jujaga @norrisng-bc @TimCsaky @jatindersingh93 @kyle1morel @wilwong89
+* @norrisng-bc @TimCsaky @jatindersingh93 @kyle1morel @wilwong89

--- a/frontend/src/utils/templates.ts
+++ b/frontend/src/utils/templates.ts
@@ -1,26 +1,36 @@
 export const roadmapTemplate = (replaceConfig: { [key: string]: string | string[] | undefined }) => {
-  // Using template literal, baseTemplate's whitespace matters
-  {/* prettier-ignore */}
-  const baseTemplate = `Dear {{ contactName }},
-
-Here is your Permit Roadmap for {{ locationAddress }},
-
-You need to apply for the following permit(s):
-{{ permitStateNew }}
-
-Based on the information provided, you may need the following permit(s):
-{{ permitPossiblyNeeded }}
-
-Based on the information provided, you have already applied for the following permit(s):
-{{ permitStateApplied }}
-
-Based on the information provided, you have completed the process for the following permit(s):
-{{ permitStateCompleted }}
-
-Regards,
-{{ navigatorName }}`;
+  const baseTemplate =
+    'Dear {{ contactName }},\n\n' +
+    'Here is your Permit Roadmap for {{ locationAddress }}.\n\n' +
+    // You need to apply for the following permit(s):
+    (replaceConfig['{{ permitStateNew }}']?.length ? templateConfig.permitStateNew : '') +
+    // Based on the information provided, you may need the following permit(s):
+    (replaceConfig['{{ permitPossiblyNeeded }}']?.length ? templateConfig.permitPossiblyNeeded : '') +
+    // Based on the information provided, you have already applied for the following permit(s):
+    (replaceConfig['{{ permitStateApplied }}']?.length ? templateConfig.permitStateApplied : '') +
+    // Based on the information provided, you have completed the process for the following permit(s):
+    (replaceConfig['{{ permitStateCompleted }}']?.length ? templateConfig.permitStateCompleted : '') +
+    'Regards,\n\n' +
+    '{{ navigatorName }}';
 
   return replacePlaceholders(baseTemplate, replaceConfig);
+};
+
+// Optional template sections - don't show if corresponding replaceConfig key is blank
+// prettier-ignore
+const templateConfig = {
+  permitStateNew:
+    'You need to apply for the following permit(s):\n' +
+    '{{ permitStateNew }}\n\n',
+  permitPossiblyNeeded:
+    'Based on the information provided, you may need the following permit(s):\n' +
+    '{{ permitPossiblyNeeded }}\n\n',
+  permitStateApplied:
+    'Based on the information provided, you have already applied for the following permit(s):\n' +
+    '{{ permitStateApplied }}\n\n',
+  permitStateCompleted:
+    'Based on the information provided, you have completed the process for the following permit(s):\n' +
+    '{{ permitStateCompleted }}\n\n'
 };
 
 const replacePlaceholders = (baseText: string, replacementConfig: { [key: string]: string | string[] | undefined }) => {

--- a/frontend/src/utils/templates.ts
+++ b/frontend/src/utils/templates.ts
@@ -8,6 +8,9 @@ Here is your Permit Roadmap for {{ locationAddress }},
 You need to apply for the following permit(s):
 {{ permitStateNew }}
 
+Based on the information provided, you may need the following permit(s):
+{{ permitPossiblyNeeded }}
+
 Based on the information provided, you have already applied for the following permit(s):
 {{ permitStateApplied }}
 

--- a/frontend/tests/unit/utils/templates.spec.ts
+++ b/frontend/tests/unit/utils/templates.spec.ts
@@ -1,0 +1,142 @@
+import { roadmapTemplate } from '@/utils/templates';
+
+/**
+ * Helper function for setting up the expected templated output.
+ * @param contactName             Contact name
+ * @param locationAddress         Location address
+ * @param permitStateNew          Required permit(s).
+ *                                 If multiple, each should be separated by a newline.
+ * @param permitPossiblyNeeded    Permit(s) that may be needed.
+ *                                 If multiple, each should be separated by a newline.
+ * @param permitStateApplied      Permit(s) that have already been applied.
+ *                                If multiple, each should be separated by a newline.
+ * @param permitStateCompleted   Permit(s) that are completed.
+ *                                If multiple, each should be separated by a newline.
+ * @param navigatorName          Navigator name
+ * @returns                       Templated output, with all the parameters substituted in.
+ */
+function setupOutputTemplate(inputs: {
+  contactName: string;
+  locationAddress: string;
+  permitStateNew: string[];
+  permitPossiblyNeeded: string[];
+  permitStateApplied: string[];
+  permitStateCompleted: string[];
+  navigatorName: string;
+}) {
+  // Note: roadmapTemplate() contains logic to add/remove sections depending on whether it contains permits.
+  //       We don't do that here - we expect the caller to remove those sections before using them in an expect(),
+  //       with something like string.replace('You need to apply...\n\n\n','')
+  return `Dear ${inputs.contactName},
+
+Here is your Permit Roadmap for ${inputs.locationAddress}.
+
+You need to apply for the following permit(s):
+${inputs.permitStateNew.join('\n')}
+
+Based on the information provided, you may need the following permit(s):
+${inputs.permitPossiblyNeeded.join('\n')}
+
+Based on the information provided, you have already applied for the following permit(s):
+${inputs.permitStateApplied.join('\n')}
+
+Based on the information provided, you have completed the process for the following permit(s):
+${inputs.permitStateCompleted.join('\n')}
+
+Regards,
+
+${inputs.navigatorName}`;
+}
+
+let replaceConfig: any = {}; // the part actually fed into the function we're testing
+const sampleInputs = {
+  contactName: 'Contact Name',
+  locationAddress: '501 Belleville St',
+  permitStateNew: ['Contaminated Sites Remediation Permit', 'Rezoning'],
+  permitPossiblyNeeded: ['Rezoning'],
+  permitStateApplied: ['Groundwater Licence - Wells'],
+  permitStateCompleted: ['Site Alteration Permit'],
+  navigatorName: 'Permit Navigator'
+};
+let testCases: any = {}; // test-specific temp object to hold the values being tested
+
+beforeEach(() => {
+  testCases = Object.assign(testCases, sampleInputs);
+  replaceConfig = {
+    '{{ contactName }}': sampleInputs.contactName,
+    '{{ locationAddress }}': sampleInputs.locationAddress,
+    '{{ permitStateNew }}': sampleInputs.permitStateNew,
+    '{{ permitPossiblyNeeded }}': sampleInputs.permitPossiblyNeeded,
+    '{{ permitStateApplied }}': sampleInputs.permitStateApplied,
+    '{{ permitStateCompleted }}': sampleInputs.permitStateCompleted,
+    '{{ navigatorName }}': sampleInputs.navigatorName
+  };
+});
+
+describe('templates.ts', () => {
+  describe('roadmapTemplate', () => {
+    it('returns a correctly-formatted roadmap message when there are permits in each section', () => {
+      expect(roadmapTemplate(replaceConfig)).toEqual(setupOutputTemplate(sampleInputs));
+    });
+
+    it('omit "required permits" section if it does not have any permits', () => {
+      testCases.permitStateNew = [];
+      replaceConfig['{{ permitStateNew }}'] = [];
+      const expectedOutput = setupOutputTemplate(testCases).replace(
+        'You need to apply for the following permit(s):\n\n\n',
+        ''
+      );
+      expect(roadmapTemplate(replaceConfig)).toEqual(expectedOutput);
+    });
+
+    it('omit "potentially required permits" section if it does not have any permits', () => {
+      testCases.permitPossiblyNeeded = [];
+      replaceConfig['{{ permitPossiblyNeeded }}'] = [];
+      const expectedOutput = setupOutputTemplate(testCases).replace(
+        'Based on the information provided, you may need the following permit(s):\n\n\n',
+        ''
+      );
+      expect(roadmapTemplate(replaceConfig)).toEqual(expectedOutput);
+    });
+
+    it('omit "already applied permits" section if it does not have any permits', () => {
+      testCases.permitStateApplied = [];
+      replaceConfig['{{ permitStateApplied }}'] = [];
+      const expectedOutput = setupOutputTemplate(testCases).replace(
+        'Based on the information provided, you have already applied for the following permit(s):\n\n\n',
+        ''
+      );
+      expect(roadmapTemplate(replaceConfig)).toEqual(expectedOutput);
+    });
+
+    it('omit "completed permits" section if it does not have any permits', () => {
+      testCases.permitStateCompleted = [];
+      replaceConfig['{{ permitStateCompleted }}'] = [];
+      const expectedOutput = setupOutputTemplate(testCases).replace(
+        'Based on the information provided, you have completed the process for the following permit(s):\n\n\n',
+        ''
+      );
+      expect(roadmapTemplate(replaceConfig)).toEqual(expectedOutput);
+    });
+
+    it('omit all permit sections if the submission does not have any associated permits', () => {
+      testCases.permitStateNew = [];
+      testCases.permitPossiblyNeeded = [];
+      testCases.permitStateApplied = [];
+      testCases.permitStateCompleted = [];
+      replaceConfig['{{ permitStateNew }}'] = [];
+      replaceConfig['{{ permitPossiblyNeeded }}'] = [];
+      replaceConfig['{{ permitStateApplied }}'] = [];
+      replaceConfig['{{ permitStateCompleted }}'] = [];
+      const expectedOutput = setupOutputTemplate(testCases)
+        .replace('You need to apply for the following permit(s):\n\n\n', '')
+        .replace('Based on the information provided, you may need the following permit(s):\n\n\n', '')
+        .replace('Based on the information provided, you have already applied for the following permit(s):\n\n\n', '')
+        .replace(
+          'Based on the information provided, you have completed the process for the following permit(s):\n\n\n',
+          ''
+        );
+      expect(roadmapTemplate(replaceConfig)).toEqual(expectedOutput);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
<!-- Describe your changes in detail -->
This adds templating to the roadmap email. 

The roadmap email body is prepopulated with the fields as specified in the wireframe ([SHOWCASE-3440](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3440)):
* Contact name
* Location address
* Permit(s) required
* Permit(s) that *may* be required
* Permit(s) already applied
* Permit(s) completed
* Navigator name

Sections without permits are omitted entirely; e.g. if no permits are required, "You need to apply for the following permits" won't appear in the email body.

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3423

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->