### PR TITLE
Remove keep-values from Form component

### DIFF
--- a/frontend/src/components/intake/ShasIntakeForm.vue
+++ b/frontend/src/components/intake/ShasIntakeForm.vue
@@ -109,7 +109,6 @@ function onPermitsHasAppliedChange(e: BASIC_RESPONSES, fieldsLength: number, pus
     }
   } else {
     setFieldValue('appliedPermits', undefined);
-    setFieldValue('permits.checkPermits', undefined);
   }
 }
 
@@ -196,7 +195,6 @@ onBeforeMount(async () => {
       id="form"
       v-slot="{ setFieldValue, values }"
       ref="formRef"
-      keep-values
       :initial-values="initialFormValues"
       :validation-schema="intakeSchema"
       @invalid-submit="(e) => displayErrors(e)"
@@ -572,11 +570,8 @@ onBeforeMount(async () => {
                       () => {
                         setFieldValue('housing.financiallySupportedBC', BASIC_RESPONSES.NO);
                         setFieldValue('housing.financiallySupportedIndigenous', BASIC_RESPONSES.NO);
-                        setFieldValue('housing.indigenousDescription', undefined);
                         setFieldValue('housing.financiallySupportedNonProfit', BASIC_RESPONSES.NO);
-                        setFieldValue('housing.nonProfitDescription', undefined);
                         setFieldValue('housing.financiallySupportedHousingCoop', BASIC_RESPONSES.NO);
-                        setFieldValue('housing.housingCoopDescription', undefined);
                       }
                     "
                   >
@@ -635,12 +630,6 @@ onBeforeMount(async () => {
                     :bold="false"
                     :disabled="!editable"
                     :options="YesNoUnsure"
-                    @on-change="
-                      (e) => {
-                        console.log(e);
-                        if (e !== BASIC_RESPONSES.YES) setFieldValue('housing.indigenousDescription', undefined);
-                      }
-                    "
                   />
                   <div class="col-12">
                     <InputText
@@ -667,12 +656,6 @@ onBeforeMount(async () => {
                     :bold="false"
                     :disabled="!editable"
                     :options="YesNoUnsure"
-                    @on-change="
-                      (e) => {
-                        console.log(e);
-                        if (e !== BASIC_RESPONSES.YES) setFieldValue('housing.nonProfitDescription', undefined);
-                      }
-                    "
                   />
                   <div class="col-12">
                     <InputText
@@ -699,12 +682,6 @@ onBeforeMount(async () => {
                     :bold="false"
                     :disabled="!editable"
                     :options="YesNoUnsure"
-                    @on-change="
-                      (e) => {
-                        console.log(e);
-                        if (e !== BASIC_RESPONSES.YES) setFieldValue('housing.housingCoopDescription', undefined);
-                      }
-                    "
                   />
                   <div class="col-12">
                     <InputText


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Due to Primevue's stepper component implementation in v3.50.0 there was a need to use Vee-Validate's `keep-values` directive on the form component to maintain form values when not displayed on screen and certain workarounds.

Updating Primevue to v3.52.0 in a prior commit has fixed that implementation and the workarounds are no longer required.
[https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-156](PADS-156)
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->