### PR TITLE
Remove .trim from form components

### DIFF
--- a/frontend/src/components/form/Checkbox.vue
+++ b/frontend/src/components/form/Checkbox.vue
@@ -30,7 +30,7 @@ const { errorMessage, value } = useField<string>(toRef(props, 'name'));
   <div class="field col">
     <div class="flex align-items-center">
       <Checkbox
-        v-model.trim="value"
+        v-model="value"
         binary
         :aria-describedby="`${name}-help`"
         :name="name"

--- a/frontend/src/components/form/EditableDropdown.vue
+++ b/frontend/src/components/form/EditableDropdown.vue
@@ -43,7 +43,7 @@ const { errorMessage, value } = useField<string>(toRef(props, 'name'));
       {{ label }}
     </label>
     <Dropdown
-      v-model.trim="value"
+      v-model="value"
       editable
       :aria-describedby="`${name}-help`"
       :name="name"

--- a/frontend/src/components/form/InputMask.vue
+++ b/frontend/src/components/form/InputMask.vue
@@ -36,7 +36,7 @@ const { errorMessage, value } = useField<string>(toRef(props, 'name'));
       {{ label }}
     </label>
     <InputMask
-      v-model.trim="value"
+      v-model="value"
       :aria-describedby="`${name}-help`"
       :name="name"
       :mask="mask"

--- a/frontend/src/components/form/InputNumber.vue
+++ b/frontend/src/components/form/InputNumber.vue
@@ -39,7 +39,7 @@ const fieldActive: Ref<boolean> = ref(false);
       {{ label }}
     </label>
     <InputNumber
-      v-model.trim="value"
+      v-model="value"
       :aria-describedby="`${name}-help`"
       :name="name"
       :placeholder="placeholder"

--- a/frontend/src/components/form/InputText.vue
+++ b/frontend/src/components/form/InputText.vue
@@ -35,7 +35,7 @@ const { errorMessage, value } = useField<string>(toRef(props, 'name'));
       {{ label }}
     </label>
     <InputText
-      v-model.trim="value"
+      v-model="value"
       :aria-describedby="`${name}-help`"
       :name="name"
       :placeholder="placeholder"

--- a/frontend/src/components/form/Password.vue
+++ b/frontend/src/components/form/Password.vue
@@ -33,7 +33,7 @@ const { errorMessage, value } = useField<string>(toRef(props, 'name'));
       {{ props.label }}
     </label>
     <Password
-      v-model.trim="value"
+      v-model="value"
       :aria-describedby="`${props.name}-help`"
       :name="props.name"
       :type="props.type"

--- a/frontend/src/components/form/TextArea.vue
+++ b/frontend/src/components/form/TextArea.vue
@@ -37,7 +37,7 @@ const { errorMessage, value } = useField<string>(toRef(props, 'name'));
       {{ label }}
     </label>
     <Textarea
-      v-model.trim="value"
+      v-model="value"
       :aria-describedby="`${name}-help`"
       :name="name"
       :placeholder="placeholder"

--- a/frontend/src/components/submission/SubmissionStatistics.vue
+++ b/frontend/src/components/submission/SubmissionStatistics.vue
@@ -121,7 +121,7 @@ watch(
         <td class="col-9">
           Submissions by assigned navigator
           <Dropdown
-            v-model.trim="statisticFilters.userId"
+            v-model="statisticFilters.userId"
             class="w-7"
             editable
             :options="assigneeOptions"


### PR DESCRIPTION
PADS-178: Bug noticed by navs where backspacing caused the whitespace to be removed automatically
Removed internal form components from the cherrypick
(cherry picked from commit d788649f29f3c253315ea794c44818f427669731)

<!-- Provide a general summary of your changes in the Title above -->
# Description

Describe your changes in detail
Slipstream fix to remove .trim from form components
58da8381f3743f2e0a578d91191a69ffe6684982 - Slipstream fix to remove .trim from form components
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
Slipstream fix to remove .trim from form components
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->