### PR TITLE
Validate confirmation Id (activityId) for Enquiries

### DIFF
--- a/app/src/controllers/activity.ts
+++ b/app/src/controllers/activity.ts
@@ -1,0 +1,25 @@
+import { activityService } from '../services';
+
+import { ACTIVITY_ID_LENGTH } from '../utils/constants/application';
+
+import type { NextFunction, Request, Response } from '../interfaces/IExpress';
+
+const controller = {
+  validateActivityId: async (req: Request<{ activityId: string }>, res: Response, next: NextFunction) => {
+    try {
+      const { activityId } = req.params;
+      const hexidecimal = parseInt(activityId, 16);
+
+      if (activityId.length !== ACTIVITY_ID_LENGTH || !hexidecimal) {
+        return res.status(400).json({ message: 'Invalid activity Id format' });
+      }
+      const activity = await activityService.getActivity(activityId);
+
+      res.status(200).json({ valid: !!activity && !activity.isDeleted });
+    } catch (e: unknown) {
+      next(e);
+    }
+  }
+};
+
+export default controller;

--- a/app/src/controllers/index.ts
+++ b/app/src/controllers/index.ts
@@ -1,3 +1,4 @@
+export { default as activityController } from './activity';
 export { default as documentController } from './document';
 export { default as enquiryController } from './enquiry';
 export { default as noteController } from './note';

--- a/app/src/routes/v1/activity.ts
+++ b/app/src/routes/v1/activity.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import { activityController } from '../../controllers';
+import { requireSomeAuth } from '../../middleware/requireSomeAuth';
+
+import type { NextFunction, Request, Response } from '../../interfaces/IExpress';
+
+const router = express.Router();
+router.use(requireSomeAuth);
+
+//** Validates an Activity Id */
+router.get('/validate/:activityId', (req: Request, res: Response, next: NextFunction): void => {
+  activityController.validateActivityId(req, res, next);
+});
+
+export default router;

--- a/app/src/routes/v1/index.ts
+++ b/app/src/routes/v1/index.ts
@@ -2,6 +2,7 @@ import { currentUser } from '../../middleware/authentication';
 
 import express from 'express';
 
+import activity from './activity';
 import document from './document';
 import enquiry from './enquiry';
 import note from './note';
@@ -17,10 +18,11 @@ router.use(currentUser);
 // Base v1 Responder
 router.get('/', (_req, res) => {
   res.status(200).json({
-    endpoints: ['/document', '/enquiry', '/note', '/permit', '/roadmap', '/sso', '/submission', '/user']
+    endpoints: ['/activity', '/document', '/enquiry', '/note', '/permit', '/roadmap', '/sso', '/submission', '/user']
   });
 });
 
+router.use('/activity', activity);
 router.use('/document', document);
 router.use('/enquiry', enquiry);
 router.use('/note', note);

--- a/app/src/utils/constants/application.ts
+++ b/app/src/utils/constants/application.ts
@@ -19,3 +19,5 @@ export const DEFAULTCORS = Object.freeze({
 export const YES_NO_LIST = [BasicResponse.YES, BasicResponse.NO];
 
 export const YES_NO_UNSURE_LIST = [BasicResponse.YES, BasicResponse.NO, BasicResponse.UNSURE];
+
+export const ACTIVITY_ID_LENGTH = 8;

--- a/app/tests/unit/controllers/activity.spec.ts
+++ b/app/tests/unit/controllers/activity.spec.ts
@@ -1,0 +1,146 @@
+import { activityController } from '../../../src/controllers';
+import { activityService } from '../../../src/services';
+
+// Mock config library - @see {@link https://stackoverflow.com/a/64819698}
+jest.mock('config');
+
+const mockResponse = () => {
+  const res: { status?: jest.Mock; json?: jest.Mock; end?: jest.Mock } = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+
+  return res;
+};
+
+let res: { status?: jest.Mock; json?: jest.Mock; end?: jest.Mock };
+beforeEach(() => {
+  res = mockResponse();
+});
+
+afterEach(() => {
+  /*
+   * Must use clearAllMocks when using the mocked config
+   * resetAllMocks seems to cause strange issues such as
+   * functions not calling as expected
+   */
+  jest.clearAllMocks();
+});
+
+const CURRENT_USER = { authType: 'BEARER', tokenPayload: null };
+
+const ACTIVITY = {
+  activityId: '12345678',
+  initiativeId: '59cd9e86-7cce-4791-b071-69002c731315',
+  isDeleted: false
+};
+
+const DELETED_ACTIVITY = {
+  activityId: '87654321',
+  initiativeId: '59cd9e86-7cce-4791-b071-69002c731315',
+  isDeleted: true
+};
+
+describe('validateActivityId', () => {
+  const next = jest.fn();
+
+  // Mock service calls
+  const activityServiceSpy = jest.spyOn(activityService, 'getActivity');
+
+  it('shoulld return status 200 and valid true if activityId exists and isDeleted is false', async () => {
+    const req = {
+      params: { activityId: '12345678' },
+      currentUser: CURRENT_USER
+    };
+
+    activityServiceSpy.mockResolvedValue(ACTIVITY);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await activityController.validateActivityId(req as any, res as any, next);
+
+    expect(activityServiceSpy).toHaveBeenCalledTimes(1);
+    expect(activityServiceSpy).toHaveBeenCalledWith(req.params.activityId);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ valid: true });
+  });
+
+  it('shoulld return status 200 and valid false if activityId exists but isDeleted is true', async () => {
+    const req = {
+      params: { activityId: '87654321' },
+      currentUser: CURRENT_USER
+    };
+
+    activityServiceSpy.mockResolvedValue(DELETED_ACTIVITY);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await activityController.validateActivityId(req as any, res as any, next);
+
+    expect(activityServiceSpy).toHaveBeenCalledTimes(1);
+    expect(activityServiceSpy).toHaveBeenCalledWith(req.params.activityId);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ valid: false });
+  });
+
+  it('shoulld return status 200 and valid false if activityId does not exist', async () => {
+    const req = {
+      params: { activityId: 'FFFFFFFF' },
+      currentUser: CURRENT_USER
+    };
+
+    activityServiceSpy.mockResolvedValue(null);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await activityController.validateActivityId(req as any, res as any, next);
+
+    expect(activityServiceSpy).toHaveBeenCalledTimes(1);
+    expect(activityServiceSpy).toHaveBeenCalledWith(req.params.activityId);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ valid: false });
+  });
+
+  it('Should return 400 and error message if activityId does not have correct length', async () => {
+    const req = {
+      params: { activityId: '12345' },
+      currentUser: CURRENT_USER
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await activityController.validateActivityId(req as any, res as any, next);
+
+    expect(activityServiceSpy).toHaveBeenCalledTimes(0);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid activity Id format' });
+  });
+
+  it('Should return 400 and error message if activityId is not hexidecimal value', async () => {
+    const req = {
+      params: { activityId: 'GGGGGGGG' },
+      currentUser: CURRENT_USER
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await activityController.validateActivityId(req as any, res as any, next);
+
+    expect(activityServiceSpy).toHaveBeenCalledTimes(0);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid activity Id format' });
+  });
+
+  it('Should call next with error if getActivity fails', async () => {
+    const req = {
+      params: { activityId: '12345678' },
+      currentUser: CURRENT_USER
+    };
+
+    const error = new Error();
+
+    activityServiceSpy.mockRejectedValue(error);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await activityController.validateActivityId(req as any, res as any, next);
+
+    expect(activityServiceSpy).toHaveBeenCalledTimes(1);
+    expect(activityServiceSpy).toHaveBeenCalledWith(req.params.activityId);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(error);
+  });
+});

--- a/frontend/src/components/housing/enquiry/EnquiryIntakeForm.vue
+++ b/frontend/src/components/housing/enquiry/EnquiryIntakeForm.vue
@@ -9,9 +9,9 @@ import { Dropdown, InputMask, RadioList, InputText, StepperNavigation, TextArea 
 import CollectionDisclaimer from '@/components/housing/CollectionDisclaimer.vue';
 import EnquiryIntakeConfirmation from '@/components/housing/enquiry/EnquiryIntakeConfirmation.vue';
 import { Button, Card, Divider, useConfirm, useToast } from '@/lib/primevue';
-import { enquiryService, submissionService } from '@/services';
+import { activityService, enquiryService, submissionService } from '@/services';
 import { useConfigStore } from '@/store';
-import { YES_NO_LIST } from '@/utils/constants/application';
+import { ACTIVITY_ID_LENGTH, YES_NO_LIST } from '@/utils/constants/application';
 import { CONTACT_PREFERENCE_LIST, PROJECT_RELATIONSHIP_LIST } from '@/utils/constants/housing';
 import { BasicResponse, Regex, RouteName } from '@/utils/enums/application';
 import { IntakeFormCategory, IntakeStatus } from '@/utils/enums/housing';
@@ -234,6 +234,23 @@ async function emailConfirmation(activityId: string) {
   };
   await submissionService.emailConfirmation(emailData);
 }
+
+async function checkActivityIdValidity(event: Event) {
+  const target = event.target as HTMLInputElement;
+  const activityId = target.value;
+  const hexidecimal = parseInt(activityId, 16);
+
+  if (activityId) {
+    if (activityId.length === ACTIVITY_ID_LENGTH && hexidecimal) {
+      const valid = (await activityService.checkActivityIdValidity(activityId)).data.valid;
+      if (!valid) {
+        toast.warn(`Confirmation ID ${activityId} does not exist, please check again.`);
+      }
+    } else {
+      toast.warn('Confirmation ID is not the right format, please check again.');
+    }
+  }
+}
 </script>
 
 <template>
@@ -369,6 +386,7 @@ async function emailConfirmation(activityId: string) {
               name="basic.relatedActivityId"
               placeholder="Confirmation ID"
               :disabled="!editable"
+              @on-change="checkActivityIdValidity"
             />
           </div>
         </template>

--- a/frontend/src/services/activityService.ts
+++ b/frontend/src/services/activityService.ts
@@ -1,0 +1,12 @@
+import { appAxios } from './interceptors';
+
+export default {
+  /**
+   * @function checkActivityIdValidity
+   * Checks if an activity ID is valid
+   * @returns {Promise} An axios response
+   */
+  checkActivityIdValidity(activityId: string) {
+    return appAxios().get(`activity/validate/${activityId}`);
+  }
+};

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,6 +1,7 @@
 export { default as AuthService } from './authService';
 export { default as ConfigService } from './configService';
 export { default as PermissionService } from './permissionService';
+export { default as activityService } from './activityService';
 export { default as comsService } from './comsService';
 export { default as documentService } from './documentService';
 export { default as enquiryService } from './enquiryService';

--- a/frontend/src/utils/constants/application.ts
+++ b/frontend/src/utils/constants/application.ts
@@ -24,3 +24,5 @@ export const SYSTEM_USER = NIL;
 
 export const YES_NO_LIST = [BasicResponse.YES, BasicResponse.NO];
 export const YES_NO_UNSURE_LIST = [BasicResponse.YES, BasicResponse.NO, BasicResponse.UNSURE];
+
+export const ACTIVITY_ID_LENGTH = 8;

--- a/frontend/src/views/DeveloperView.vue
+++ b/frontend/src/views/DeveloperView.vue
@@ -17,10 +17,6 @@ const { getConfig } = storeToRefs(useConfigStore());
 const permissionService = new PermissionService();
 const router = useRouter();
 
-async function ssoRequestBasicAccess() {
-  await permissionService.requestBasicAccess();
-}
-
 async function searchIdirUsers() {
   await permissionService.searchIdirUsers({ firstName: 'Kyle' });
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Made it so that a warning toast pops out when the confirmation id (activityId) entered by the proponent doesn't return a submissions search result.
Proponents will now be visually told that they are entering an invalid id but not stopped from doing so.
[PADS-181](https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-181)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->