### PR TITLE
Help text for Form components always shows (like Parcel Ids on submission intake)

### DIFF
--- a/frontend/src/components/form/InputNumber.vue
+++ b/frontend/src/components/form/InputNumber.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
-import { toRef, ref } from 'vue';
+import { toRef } from 'vue';
 import { useField, ErrorMessage } from 'vee-validate';
 
 import { InputNumber } from '@/lib/primevue';
-
-import type { Ref } from 'vue';
 
 // Props
 type Props = {
@@ -27,10 +25,6 @@ const props = withDefaults(defineProps<Props>(), {
 
 // State
 const { errorMessage, value } = useField<number>(toRef(props, 'name'));
-const fieldActive: Ref<boolean> = ref(false);
-
-// Emits
-const emit = defineEmits(['onBlur', 'onFocus']);
 </script>
 
 <template>
@@ -51,23 +45,8 @@ const emit = defineEmits(['onBlur', 'onFocus']);
       :disabled="disabled"
       :min-fraction-digits="0"
       :max-fraction-digits="6"
-      @blur="
-        () => {
-          fieldActive = true;
-          emit('onBlur');
-        }
-      "
-      @focus="
-        () => {
-          fieldActive = true;
-          emit('onFocus');
-        }
-      "
     />
-    <small
-      v-if="fieldActive"
-      :id="`${name}-help`"
-    >
+    <small :id="`${name}-help`">
       {{ helpText }}
     </small>
     <div class="mt-2">

--- a/frontend/src/components/form/InputText.vue
+++ b/frontend/src/components/form/InputText.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
 import { ErrorMessage } from 'vee-validate';
-import { ref } from 'vue';
 
 import InputTextInternal from './internal/InputTextInternal.vue';
 import { FloatLabel } from '@/lib/primevue';
-
-import type { Ref } from 'vue';
 
 // Props
 type Props = {
@@ -30,9 +27,6 @@ const props = withDefaults(defineProps<Props>(), {
 
 // Emits
 const emit = defineEmits(['onChange']);
-
-// State
-const fieldActive: Ref<boolean> = ref(false);
 </script>
 
 <template>
@@ -45,15 +39,11 @@ const fieldActive: Ref<boolean> = ref(false);
     </FloatLabel>
     <InputTextInternal
       v-else
-      v-model:fieldActive="fieldActive"
       v-bind="props"
       @on-change="(e) => emit('onChange', e)"
     />
 
-    <small
-      v-if="fieldActive"
-      :id="`${name}-help`"
-    >
+    <small :id="`${name}-help`">
       {{ helpText }}
     </small>
     <div class="mt-2">

--- a/frontend/src/components/form/internal/InputTextInternal.vue
+++ b/frontend/src/components/form/internal/InputTextInternal.vue
@@ -22,7 +22,6 @@ const emit = defineEmits(['onChange']);
 
 // State
 const { errorMessage, value } = useField<string>(toRef(props, 'name'));
-const fieldActive = defineModel<boolean>('fieldActive');
 </script>
 
 <template>
@@ -40,8 +39,6 @@ const fieldActive = defineModel<boolean>('fieldActive');
     class="w-full"
     :class="{ 'p-invalid': errorMessage }"
     :disabled="disabled"
-    @focus="fieldActive = true"
-    @blur="fieldActive = false"
     @change="(e) => emit('onChange', e)"
   />
 </template>


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
# Description

Help text on form components like InputText now always displays
so that the user can see the help text without needing to clicking into field, saving confusion
[PADS-245](https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-245)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->