### PR TITLE
BF Notes now being reassigned

### DIFF
--- a/frontend/src/components/housing/submission/SubmissionBringForwardCalendar.vue
+++ b/frontend/src/components/housing/submission/SubmissionBringForwardCalendar.vue
@@ -20,10 +20,12 @@ const NOTES_TAB_INDEX = {
 // Props
 type Props = {
   bringForward?: Array<BringForward>;
+  myAssignedTo: Set<string>;
 };
 
 const props = withDefaults(defineProps<Props>(), {
-  bringForward: () => []
+  bringForward: () => [],
+  myAssignedTo: () => new Set<string>()
 });
 
 // Store
@@ -53,6 +55,10 @@ function getQueryObject(bf: BringForward) {
     enquiryId: bf.enquiryId
   };
 }
+
+function filterForMyBringForwards(bf: BringForward): boolean {
+  return bf.createdByFullName === getProfile.value?.name || props.myAssignedTo.has(bf.submissionId ?? '');
+}
 </script>
 
 <template>
@@ -69,7 +75,8 @@ function getQueryObject(bf: BringForward) {
         class="text-left w-full"
         :value="
           bringForwards.filter((x) => {
-            return filterToUser ? x.createdByFullName === getProfile?.name : x;
+            // return x.createdByFullName === getProfile?.name;
+            return filterToUser ? filterForMyBringForwards(x) : x;
           })
         "
         data-key="noteId"
@@ -108,7 +115,7 @@ function getQueryObject(bf: BringForward) {
         </Column>
         <Column
           field="createdByFullName"
-          header="Navigator"
+          header="Author"
           :sortable="true"
         />
         <Column

--- a/frontend/src/types/Submission.ts
+++ b/frontend/src/types/Submission.ts
@@ -1,4 +1,5 @@
 import type { IStamps } from '@/interfaces';
+import type { User } from './User';
 
 export type Submission = {
   activityId: string;
@@ -50,4 +51,5 @@ export type Submission = {
   assignedUserId?: string;
   applicationStatus: string;
   waitingOn?: string;
+  user?: User;
 } & Partial<IStamps>;

--- a/frontend/tests/unit/components/submission/SubmissionBringForwardCalendar.spec.ts
+++ b/frontend/tests/unit/components/submission/SubmissionBringForwardCalendar.spec.ts
@@ -34,9 +34,12 @@ const bringForward: Array<BringForward> = [
   }
 ];
 
+const myAssignedTo: Set<string> = new Set([]);
+
 const wrapperSettings = () => ({
   props: {
-    bringForward: bringForward
+    bringForward: bringForward,
+    myAssignedTo: myAssignedTo
   },
   global: {
     plugins: [


### PR DESCRIPTION
BF notifications accordion and show mine only list in BF Calendar now both show notes authored and assigned to

<!-- Provide a general summary of your changes in the Title above -->
# Description

Capture the submissions/projects that a user is assigned to and cross reference that with BF Notes connected to said assigned projects.
So that when a navigator assigns someone else to the project they will also get the bring forward notification
[PADS-244](https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-244)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->