### PR TITLE
Fixed autosave from triggering on empty forms

### DIFF
--- a/frontend/src/components/form/internal/InputMaskInternal.vue
+++ b/frontend/src/components/form/internal/InputMaskInternal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useField } from 'vee-validate';
 
 import { InputMask } from '@/lib/primevue';
@@ -14,6 +15,15 @@ const { label, name, mask, placeholder, disabled, bold } = defineProps<{
 }>();
 
 const { errorMessage, value } = useField<string>(name);
+
+const normalizedValue = computed({
+  get: () => {
+    return value.value === '' ? undefined : value.value;
+  },
+  set: (val) => {
+    value.value = val === '' || val === undefined ? (undefined as unknown as string) : val;
+  }
+});
 </script>
 
 <template>
@@ -25,7 +35,7 @@ const { errorMessage, value } = useField<string>(name);
     {{ label }}
   </label>
   <InputMask
-    v-model="value"
+    v-model="normalizedValue"
     :aria-describedby="`${name}-help`"
     :aria-labelledby="`${name}-label`"
     :name="name"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

When changing steps in the submission intake form autosave is no longer triggered, onBlur for phone number doesn't trigger autosave anymore, and no more double autosave on initial save of draft.
Keeps empty drafts from cluttering the draft and submissions table.

[PADS-337](https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-337)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
