### PR TITLE
Permit Add update button now greyed out for completed projects

### DIFF
--- a/frontend/src/components/permit/PermitCard.vue
+++ b/frontend/src/components/permit/PermitCard.vue
@@ -83,7 +83,7 @@ function isCompleted(authStatus: string | undefined): boolean {
           <Button
             class="p-button-outlined"
             aria-label="Add updates"
-            :disabled="!useAuthZStore().can(Initiative.HOUSING, Resource.PERMIT, Action.UPDATE)"
+            :disabled="!editable || !useAuthZStore().can(Initiative.HOUSING, Resource.PERMIT, Action.UPDATE)"
             @click="NotesModalVisible = true"
           >
             <font-awesome-icon


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Made it so Add updates for permit card also greyouts like the edit button
completed projects shouldn't have new info coming in
[PR-389](https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-389)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->