### PR TITLE
Ubuntu 24 no longer has `oc` by default

### DIFF
--- a/.github/workflows/on-pr-closed.yaml
+++ b/.github/workflows/on-pr-closed.yaml
@@ -30,6 +30,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Install oc-cli
+      uses: redhat-actions/openshift-tools-installer@v1
+      with:
+        oc: "4.16"
     - name: Login to OpenShift Cluster
       uses: redhat-actions/oc-login@v1
       with:

--- a/.github/workflows/on-pr-opened.yaml
+++ b/.github/workflows/on-pr-opened.yaml
@@ -48,6 +48,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install oc-cli
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.16"
       - name: Deploy to Dev
         uses: ./.github/actions/deploy-to-environment
         with:

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -45,6 +45,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install oc-cli
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.16"
       - name: Deploy to Dev
         uses: ./.github/actions/deploy-to-environment
         with:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Ubuntu latest (24.04) no longer installs `oc` by default. Have to manually add this step to the pipeline. Pegging to `4.16`. This will default to the latest patch version of 4.16.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->