### PR TITLE
Prevent autosave from clearing form error messages.

### DIFF
--- a/frontend/src/components/file/AdvancedFileUpload.vue
+++ b/frontend/src/components/file/AdvancedFileUpload.vue
@@ -30,7 +30,6 @@ const { getConfig } = storeToRefs(useConfigStore());
 const submissionStore = useSubmissionStore();
 
 // State
-// const curActivityId: Ref<string | undefined> = ref(undefined);
 const fileInput: Ref<any> = ref(null);
 const uploading: Ref<Boolean> = ref(false);
 

--- a/frontend/src/components/housing/submission/SubmissionIntakeForm.vue
+++ b/frontend/src/components/housing/submission/SubmissionIntakeForm.vue
@@ -429,12 +429,7 @@ function syncFormAndRoute(actId: string, drftId: string) {
   }
 
   if (actId) {
-    formRef.value?.resetForm({
-      values: {
-        ...formRef.value?.values,
-        activityId: actId
-      }
-    });
+    formRef.value?.setFieldValue('activityId', actId);
   }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Autosave no longer tracks activity Id within the form as it isn't a form field that needs to be tracked for autosave and validation.
This will prevent autosave from either double saving or removing validation errors.
[PADS-416](https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-416)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->