### PR TITLE
Permit notes now updating on new permits

### DIFF
--- a/frontend/src/components/permit/PermitCard.vue
+++ b/frontend/src/components/permit/PermitCard.vue
@@ -25,7 +25,6 @@ const { editable, permit } = defineProps<{
 const { getPermitTypes } = storeToRefs(useTypeStore());
 
 // State
-const cardData = computed(() => permit);
 const cardUpdatedBy: Ref<string> = ref('');
 const permitModalVisible: Ref<boolean> = ref(false);
 const notesModalVisible: Ref<boolean> = ref(false);
@@ -36,9 +35,9 @@ const permitTypeName = computed(() => permitType.value?.name ?? '');
 
 // Actions
 watchEffect(() => {
-  if (cardData.value.updatedBy) {
+  if (permit.updatedBy) {
     userService
-      .searchUsers({ userId: [cardData.value.updatedBy] })
+      .searchUsers({ userId: [permit.updatedBy] })
       .then((res) => {
         cardUpdatedBy.value = res?.data.length ? res?.data[0].fullName : '';
       })
@@ -66,7 +65,7 @@ function isCompleted(authStatus: string | undefined): boolean {
 </script>
 
 <template>
-  <Card :class="{ completed: isCompleted(cardData.authStatus), selected: notesModalVisible }">
+  <Card :class="{ completed: isCompleted(permit.authStatus), selected: notesModalVisible }">
     <template #title>
       <div class="flex">
         <div class="grow">
@@ -112,26 +111,26 @@ function isCompleted(authStatus: string | undefined): boolean {
         <div class="grid grid-cols-1 space-y-4">
           <p>
             <span class="key font-bold">Tracking ID:</span>
-            {{ cardData.trackingId }}
+            {{ permit.trackingId }}
           </p>
           <p>
             <span class="key font-bold">Status verified date:</span>
-            {{ cardData.statusLastVerified ? formatDate(cardData.statusLastVerified) : undefined }}
+            {{ permit.statusLastVerified ? formatDate(permit.statusLastVerified) : undefined }}
           </p>
           <p>
             <span class="key font-bold">Submitted date:</span>
-            {{ cardData.submittedDate ? formatDate(cardData.submittedDate) : undefined }}
+            {{ permit.submittedDate ? formatDate(permit.submittedDate) : undefined }}
           </p>
           <p>
             <span class="key font-bold">Permit state:</span>
-            {{ cardData.status }}
+            {{ permit.status }}
           </p>
         </div>
         <!-- Middle column -->
         <div class="grid grid-cols-1 space-y-4">
           <p>
             <span class="key font-bold">Last updated:</span>
-            {{ cardData.updatedAt ? ` ${formatDateTime(cardData.updatedAt)}` : undefined }}
+            {{ permit.updatedAt ? ` ${formatDateTime(permit.updatedAt)}` : undefined }}
           </p>
           <p>
             <span class="key font-bold">Updated by:</span>
@@ -139,11 +138,11 @@ function isCompleted(authStatus: string | undefined): boolean {
           </p>
           <p>
             <span class="key font-bold">Adjudication date:</span>
-            {{ cardData.adjudicationDate ? formatDate(cardData.adjudicationDate) : undefined }}
+            {{ permit.adjudicationDate ? formatDate(permit.adjudicationDate) : undefined }}
           </p>
           <p>
             <span class="key font-bold">Issued Permit ID:</span>
-            {{ cardData.issuedPermitId }}
+            {{ permit.issuedPermitId }}
           </p>
         </div>
         <!-- Right column -->
@@ -162,18 +161,18 @@ function isCompleted(authStatus: string | undefined): boolean {
           </p>
           <p>
             <span class="key font-bold">Needed:</span>
-            {{ cardData.needed }}
+            {{ permit.needed }}
           </p>
         </div>
       </div>
       <div
-        v-if="cardData.permitNote?.length"
+        v-if="permit.permitNote?.length"
         class="pb-2 pt-3"
       >
         <span class="key font-bold">Latest update for the client:</span>
         <div class="pt-3">
-          <span class="font-bold">{{ ' ' + formatDateTime(cardData.permitNote[0].createdAt) }},</span>
-          {{ cardData.permitNote[0].note }}
+          <span class="font-bold">{{ ' ' + formatDateTime(permit.permitNote[0].createdAt) }},</span>
+          {{ permit.permitNote[0].note }}
         </div>
         <div>
           <Button
@@ -190,12 +189,12 @@ function isCompleted(authStatus: string | undefined): boolean {
 
   <PermitModal
     v-model:visible="permitModalVisible"
-    :activity-id="cardData.activityId"
-    :permit="cardData"
+    :activity-id="permit.activityId"
+    :permit="permit"
   />
   <NotesModal
     v-model:visible="notesModalVisible"
-    :permit="cardData"
+    :permit="permit"
     :permit-name="permitTypeName"
   />
 </template>

--- a/frontend/src/views/housing/submission/SubmissionView.vue
+++ b/frontend/src/views/housing/submission/SubmissionView.vue
@@ -204,7 +204,7 @@ onMounted(async () => {
     <TabList>
       <Tab :value="0">Information</Tab>
       <Tab :value="1">Files</Tab>
-      <Tab :value="2">Permit</Tab>
+      <Tab :value="2">Permits</Tab>
       <Tab :value="3">Notes</Tab>
       <Tab :value="4">Roadmap</Tab>
       <Tab :value="5">Related enquiries</Tab>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Made it so new updates were also updating the store and not just component local notes list.
So that when new notes were added to a new permit they'd appear on the page without refresh
[PADS-435](https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-435)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->