### PR TITLE
chore(ci): Prevent tests from running multiple times on PRs

### DIFF
--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pr-closed.yaml
+++ b/.github/workflows/on-pr-closed.yaml
@@ -15,7 +15,7 @@ on:
       - closed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/on-pr-opened.yaml
+++ b/.github/workflows/on-pr-opened.yaml
@@ -17,7 +17,7 @@ on:
       - synchronize
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -13,7 +13,7 @@ on:
       - v*.*.*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -2,13 +2,26 @@
 name: Tests
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - '**'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-app:
     name: Unit Tests (App)
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
     defaults:
       run:
         working-directory: app
@@ -75,6 +88,9 @@ jobs:
   test-frontend:
     name: Unit Tests (Frontend)
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves the long multi-year issue with our pipelines having both PR and Push events double-run our unit tests. New behaviour:
- Push to any branch: Always run.,
- PR from fork: Run.
- PR from same repo: Skip.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
- Note that this change will not take effect on the repository until it is merged into the default branch.
- Future PRs with this change should properly skip the pull_request event if it originates from the same repository.