### PR TITLE
fix: correctly set assignedUser for navigator forms

### DIFF
--- a/frontend/src/components/electrification/project/ProjectFormNavigator.vue
+++ b/frontend/src/components/electrification/project/ProjectFormNavigator.vue
@@ -291,7 +291,7 @@ const onSubmit = async (formValues: GenericObject) => {
       astNotes: values.astNotes.notes,
 
       // Submission State
-      assignedUserId: values.submissionState.assignedUser ? (values.submissionState.assignedUser as User).userId : null,
+      assignedUserId: (values.submissionState.assignedUser as User)?.userId ?? null,
       applicationStatus: values.submissionState.applicationStatus,
       submissionType: values.submissionState.submissionType,
       queuePriority: values.submissionState.queuePriority,

--- a/frontend/src/components/general/project/ProjectFormNavigator.vue
+++ b/frontend/src/components/general/project/ProjectFormNavigator.vue
@@ -300,7 +300,7 @@ const onSubmit = async (formValues: GenericObject) => {
       astNotes: values.astNotes.notes,
 
       // Submission State
-      assignedUserId: values.submissionState.assignedUser ? (values.submissionState.assignedUser as User).userId : null,
+      assignedUserId: (values.submissionState.assignedUser as User)?.userId ?? null,
       region: values.submissionState.region as Region,
       area: values.submissionState.area as Area,
       applicationStatus: values.submissionState.applicationStatus,

--- a/frontend/src/components/housing/project/ProjectFormNavigator.vue
+++ b/frontend/src/components/housing/project/ProjectFormNavigator.vue
@@ -215,7 +215,7 @@ async function initializeFormValues(project: HousingProject): Promise<DeepPartia
     submissionState: {
       queuePriority: project.queuePriority,
       submissionType: project.submissionType,
-      assignedUser: assigneeOptions[0]?.fullName ?? null,
+      assignedUser: assigneeOptions[0] ?? null,
       applicationStatus: project.applicationStatus
     },
 
@@ -338,7 +338,7 @@ const onSubmit = async (formValues: GenericObject) => {
       astNotes: values.astNotes.notes,
 
       // Submission State
-      assignedUserId: values.submissionState.assignedUser ? (values.submissionState.assignedUser as User).userId : null,
+      assignedUserId: (values.submissionState.assignedUser as User)?.userId ?? null,
       applicationStatus: values.submissionState.applicationStatus,
       submissionType: values.submissionState.submissionType,
       queuePriority: values.submissionState.queuePriority,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

This PR fixes an issue in the housing navigator form where the `assignedUser` was not being correctly set on form load.

https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-814

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->