### PR TITLE
feat: allow specific Navigator groups to manage project teams

### DIFF
--- a/app/src/controllers/accessRequest.ts
+++ b/app/src/controllers/accessRequest.ts
@@ -38,15 +38,18 @@ const isUserAdmin = async (
 const removeUserGroups = async (
   tx: PrismaTransactionClient,
   sub: string,
-  currentInitiativeId: string,
+  currentInitiative: Initiative,
   userGroups: Group[]
 ) => {
+  // Get the current initiative
+  const currentInitiativeId = (await getInitiative(tx, currentInitiative)).initiativeId;
+
   // Remove current initiative groups
   const currentInitiativeGroups = userGroups.filter((x) => x.initiativeId === currentInitiativeId);
   await Promise.all(currentInitiativeGroups.map(async (x) => await removeGroup(tx, sub, x.groupId)));
 
   // Only remove global perm if user has no groups of the same type assigned in other initiatives
-  if (!(await subjectHasGroupName(tx, sub, currentInitiativeGroups[0]?.name))) {
+  if (!(await subjectHasGroupName(tx, sub, [currentInitiativeGroups[0]?.name], currentInitiative))) {
     const correspondingGlobalGroups = await Promise.all(
       currentInitiativeGroups.map(async (x) => await getCorrespondingGlobalGroup(tx, x.groupId))
     );
@@ -112,12 +115,9 @@ export const createUserAccessRequestController = async (
     const isGroupUpdate = existingUser && accessRequest.grant && userAlreadyInInitiative;
     let data;
 
-    // Store the current initiative ID to reference
-    const currentInitiativeId = (await getInitiative(tx, req.currentContext.initiative)).initiativeId;
-
     if (isGroupUpdate) {
       // Remove current initiative groups
-      await removeUserGroups(tx, userResponse.sub, currentInitiativeId, accessUserGroups);
+      await removeUserGroups(tx, userResponse.sub, req.currentContext.initiative, accessUserGroups);
 
       // Assign new groups
       await assignGroup(tx, userResponse.sub, accessRequest.groupId);
@@ -147,7 +147,7 @@ export const createUserAccessRequestController = async (
         };
       } else {
         // Remove current initiative groups
-        await removeUserGroups(tx, userResponse.sub, currentInitiativeId, accessUserGroups);
+        await removeUserGroups(tx, userResponse.sub, req.currentContext.initiative, accessUserGroups);
       }
     } else {
       data = await createUserAccessRequest(tx, {
@@ -193,11 +193,8 @@ export const processUserAccessRequestController = async (
             await assignGroup(tx, userResponse.sub, accessRequest.groupId);
             await assignGroup(tx, userResponse.sub, correspondingGlobalGroup.groupId);
           } else {
-            // Get the current initiative
-            const currentInitiativeId = (await getInitiative(tx, req.currentContext.initiative)).initiativeId;
-
             // Remove all user groups for the initiative
-            await removeUserGroups(tx, userResponse.sub, currentInitiativeId, userGroups);
+            await removeUserGroups(tx, userResponse.sub, req.currentContext.initiative, userGroups);
           }
 
           // Update access request status

--- a/app/src/controllers/accessRequest.ts
+++ b/app/src/controllers/accessRequest.ts
@@ -49,7 +49,7 @@ const removeUserGroups = async (
   await Promise.all(currentInitiativeGroups.map(async (x) => await removeGroup(tx, sub, x.groupId)));
 
   // Only remove global perm if user has no groups of the same type assigned in other initiatives
-  if (!(await subjectHasGroupName(tx, sub, [currentInitiativeGroups[0]?.name], currentInitiative))) {
+  if (!(await subjectHasGroupName(tx, sub, currentInitiativeGroups[0]?.name))) {
     const correspondingGlobalGroups = await Promise.all(
       currentInitiativeGroups.map(async (x) => await getCorrespondingGlobalGroup(tx, x.groupId))
     );

--- a/app/src/controllers/yars.ts
+++ b/app/src/controllers/yars.ts
@@ -47,7 +47,7 @@ export const deleteSubjectGroupController = async (
     await removeGroup(tx, req.body.sub, req.body.groupId);
 
     // Only remove global perm if user has no groups of the same type assigned in other initiatives
-    if (!(await subjectHasGroupName(tx, req.body.sub, [group?.name], req.currentContext.initiative))) {
+    if (!(await subjectHasGroupName(tx, req.body.sub, group?.name))) {
       const correspondingGlobalGroup = await getCorrespondingGlobalGroup(tx, req.body.groupId);
       await removeGroup(tx, req.body.sub, correspondingGlobalGroup.groupId);
     }

--- a/app/src/controllers/yars.ts
+++ b/app/src/controllers/yars.ts
@@ -47,7 +47,7 @@ export const deleteSubjectGroupController = async (
     await removeGroup(tx, req.body.sub, req.body.groupId);
 
     // Only remove global perm if user has no groups of the same type assigned in other initiatives
-    if (!(await subjectHasGroupName(tx, req.body.sub, group?.name))) {
+    if (!(await subjectHasGroupName(tx, req.body.sub, [group?.name], req.currentContext.initiative))) {
       const correspondingGlobalGroup = await getCorrespondingGlobalGroup(tx, req.body.groupId);
       await removeGroup(tx, req.body.sub, correspondingGlobalGroup.groupId);
     }

--- a/app/src/middleware/requireActivityAdmin.ts
+++ b/app/src/middleware/requireActivityAdmin.ts
@@ -1,11 +1,14 @@
 import { transactionWrapper } from '../db/utils/transactionWrapper.ts';
 import { listActivityContacts } from '../services/activityContact.ts';
 import { searchContacts } from '../services/contact.ts';
+import { getSubjectGroups } from '../services/yars.ts';
 import { Problem } from '../utils/index.ts';
+import { GroupName } from '../utils/enums/application.ts';
 import { ActivityContactRole } from '../utils/enums/projectCommon.ts';
 
 import type { NextFunction, Request, Response } from 'express';
 import type { PrismaTransactionClient } from '../db/dataConnection.ts';
+import type { Group } from '../types/stuff';
 
 /**
  * Verify requesting user has elevated priviledges on the requested activity
@@ -26,16 +29,24 @@ export const requireActivityAdmin = async (
     if (req.currentAuthorization.attributes.includes('scope:all')) return next();
 
     await transactionWrapper<void>(async (tx: PrismaTransactionClient) => {
+      let groups: Group[] = [];
+
+      // Proponent team member role check
       const contact = await searchContacts(tx, { userId: [req.currentContext.userId as string] });
       const activityContacts = await listActivityContacts(tx, req.params.activityId);
       const activityContact = activityContacts.find((ac) => ac.contactId === contact[0].contactId);
-      if (
-        !activityContact ||
-        (activityContact &&
-          ![ActivityContactRole.PRIMARY, ActivityContactRole.ADMIN].includes(
-            activityContact.role as ActivityContactRole
-          ))
-      ) {
+
+      const isActivityAdmin =
+        activityContact &&
+        [ActivityContactRole.PRIMARY, ActivityContactRole.ADMIN].includes(activityContact.role as ActivityContactRole);
+
+      // Navigator group check
+      if (req.currentContext.tokenPayload?.sub)
+        groups = await getSubjectGroups(tx, req.currentContext.tokenPayload?.sub);
+      const adminGroups: GroupName[] = [GroupName.SUPERVISOR, GroupName.NAVIGATOR];
+      const isGroupAdmin = groups.some((x) => adminGroups.some((g) => g === x.name));
+
+      if (!isActivityAdmin && !isGroupAdmin) {
         throw new Error('User lacks required role.');
       }
     });

--- a/app/src/middleware/requireActivityAdmin.ts
+++ b/app/src/middleware/requireActivityAdmin.ts
@@ -1,7 +1,7 @@
 import { transactionWrapper } from '../db/utils/transactionWrapper.ts';
 import { listActivityContacts } from '../services/activityContact.ts';
 import { searchContacts } from '../services/contact.ts';
-import { subjectHasGroupName } from '../services/yars.ts';
+import { subjectHasInitiativeGroupName } from '../services/yars.ts';
 import { Problem } from '../utils/index.ts';
 import { GroupName } from '../utils/enums/application.ts';
 import { ActivityContactRole } from '../utils/enums/projectCommon.ts';
@@ -28,24 +28,30 @@ export const requireActivityAdmin = async (
     if (req.currentAuthorization.attributes.includes('scope:all')) return next();
 
     await transactionWrapper<void>(async (tx: PrismaTransactionClient) => {
-      // Proponent team member role check
-      const contact = await searchContacts(tx, { userId: [req.currentContext.userId as string] });
-      const activityContacts = await listActivityContacts(tx, req.params.activityId);
-      const activityContact = activityContacts.find((ac) => ac.contactId === contact[0].contactId);
-
-      const isActivityAdmin =
-        activityContact &&
-        [ActivityContactRole.PRIMARY, ActivityContactRole.ADMIN].includes(activityContact.role as ActivityContactRole);
+      let isActivityAdmin = false;
+      let isGroupAdmin = false;
 
       // Navigator group check
-      let isGroupAdmin = false;
       if (req.currentContext.tokenPayload?.sub)
-        isGroupAdmin = await subjectHasGroupName(
+        isGroupAdmin = await subjectHasInitiativeGroupName(
           tx,
           req.currentContext.tokenPayload?.sub,
-          [GroupName.SUPERVISOR, GroupName.NAVIGATOR],
-          req.currentContext.initiative
+          req.currentContext.initiative,
+          [GroupName.SUPERVISOR, GroupName.NAVIGATOR]
         );
+
+      if (!isGroupAdmin) {
+        // Proponent team member role check
+        const contact = await searchContacts(tx, { userId: [req.currentContext.userId as string] });
+        const activityContacts = await listActivityContacts(tx, req.params.activityId);
+        const activityContact = activityContacts.find((ac) => ac.contactId === contact[0].contactId);
+
+        isActivityAdmin =
+          !!activityContact &&
+          [ActivityContactRole.PRIMARY, ActivityContactRole.ADMIN].includes(
+            activityContact.role as ActivityContactRole
+          );
+      }
 
       if (!isActivityAdmin && !isGroupAdmin) {
         throw new Error('User lacks required role.');

--- a/app/src/middleware/requireActivityAdmin.ts
+++ b/app/src/middleware/requireActivityAdmin.ts
@@ -1,14 +1,13 @@
 import { transactionWrapper } from '../db/utils/transactionWrapper.ts';
 import { listActivityContacts } from '../services/activityContact.ts';
 import { searchContacts } from '../services/contact.ts';
-import { getSubjectGroups } from '../services/yars.ts';
+import { subjectHasGroupName } from '../services/yars.ts';
 import { Problem } from '../utils/index.ts';
 import { GroupName } from '../utils/enums/application.ts';
 import { ActivityContactRole } from '../utils/enums/projectCommon.ts';
 
 import type { NextFunction, Request, Response } from 'express';
 import type { PrismaTransactionClient } from '../db/dataConnection.ts';
-import type { Group } from '../types/stuff';
 
 /**
  * Verify requesting user has elevated priviledges on the requested activity
@@ -29,8 +28,6 @@ export const requireActivityAdmin = async (
     if (req.currentAuthorization.attributes.includes('scope:all')) return next();
 
     await transactionWrapper<void>(async (tx: PrismaTransactionClient) => {
-      let groups: Group[] = [];
-
       // Proponent team member role check
       const contact = await searchContacts(tx, { userId: [req.currentContext.userId as string] });
       const activityContacts = await listActivityContacts(tx, req.params.activityId);
@@ -41,10 +38,14 @@ export const requireActivityAdmin = async (
         [ActivityContactRole.PRIMARY, ActivityContactRole.ADMIN].includes(activityContact.role as ActivityContactRole);
 
       // Navigator group check
+      let isGroupAdmin = false;
       if (req.currentContext.tokenPayload?.sub)
-        groups = await getSubjectGroups(tx, req.currentContext.tokenPayload?.sub);
-      const adminGroups: GroupName[] = [GroupName.SUPERVISOR, GroupName.NAVIGATOR];
-      const isGroupAdmin = groups.some((x) => adminGroups.some((g) => g === x.name));
+        isGroupAdmin = await subjectHasGroupName(
+          tx,
+          req.currentContext.tokenPayload?.sub,
+          [GroupName.SUPERVISOR, GroupName.NAVIGATOR],
+          req.currentContext.initiative
+        );
 
       if (!isActivityAdmin && !isGroupAdmin) {
         throw new Error('User lacks required role.');

--- a/app/src/services/sso.ts
+++ b/app/src/services/sso.ts
@@ -53,7 +53,7 @@ function ssoAxios(): AxiosInstance {
 export const searchIdirUsers = async (params?: IdirSearchParameters) => {
   try {
     const env = config.get('server.env');
-    const { data, status } = await ssoAxios().get(`/${env}/idir/users`, { params: params });
+    const { data, status } = await ssoAxios().get(`/${env}/azure-idir/users`, { params: params });
     return { data: data.data, status };
   } catch (e: unknown) {
     if (axios.isAxiosError(e)) {

--- a/app/src/services/yars.ts
+++ b/app/src/services/yars.ts
@@ -308,6 +308,7 @@ export const removeGroup = async (tx: PrismaTransactionClient, sub: string, grou
 };
 
 /**
+ * Check if a subject belongs to a specific group ID
  * @param tx Prisma transaction client
  * @param sub The subject of the current user
  * @param groupId The ID of the group to check
@@ -325,21 +326,55 @@ export const subjectHasGroup = async (tx: PrismaTransactionClient, sub: string, 
 };
 
 /**
+ * Check if a subject belongs to a specific group name, excluding the global group
  * @param tx Prisma transaction client
  * @param sub The subject of the current user
  * @param groupName The name of the group to check
- * @param initiativeCode Optional Initiative to filter on
  * @returns A Promise that resolves to a boolean
  */
 export const subjectHasGroupName = async (
   tx: PrismaTransactionClient,
   sub: string,
-  groupName: (GroupName | undefined)[],
-  initiativeCode: Initiative
+  groupName: GroupName | undefined
 ) => {
   if (!groupName) return false;
 
-  const groupArray: GroupName[] = groupName.filter(Boolean) as GroupName[];
+  const count = await tx.subject_group.count({
+    where: {
+      sub: sub,
+      group: {
+        name: groupName
+      },
+      NOT: {
+        group: {
+          initiative: {
+            code: Initiative.PCNS
+          }
+        }
+      }
+    }
+  });
+
+  return count > 0;
+};
+
+/**
+ * Check if a subject belongs to a specific set of group names within an initiative
+ * @param tx Prisma transaction client
+ * @param sub The subject of the current user
+ * @param initiativeCode Initiative the groups belong to
+ * @param groupNames Array of group names to check
+ * @returns A Promise that resolves to a boolean
+ */
+export const subjectHasInitiativeGroupName = async (
+  tx: PrismaTransactionClient,
+  sub: string,
+  initiativeCode: Initiative,
+  groupNames: (GroupName | undefined)[]
+) => {
+  const groupArray: GroupName[] = groupNames.filter(Boolean) as GroupName[];
+
+  if (groupNames.length === 0) return false;
 
   const count = await tx.subject_group.count({
     where: {

--- a/app/src/services/yars.ts
+++ b/app/src/services/yars.ts
@@ -328,27 +328,25 @@ export const subjectHasGroup = async (tx: PrismaTransactionClient, sub: string, 
  * @param tx Prisma transaction client
  * @param sub The subject of the current user
  * @param groupName The name of the group to check
+ * @param initiativeCode Optional Initiative to filter on
  * @returns A Promise that resolves to a boolean
  */
 export const subjectHasGroupName = async (
   tx: PrismaTransactionClient,
   sub: string,
-  groupName: GroupName | undefined
+  groupName: (GroupName | undefined)[],
+  initiativeCode: Initiative
 ) => {
   if (!groupName) return false;
+
+  const groupArray: GroupName[] = groupName.filter(Boolean) as GroupName[];
 
   const count = await tx.subject_group.count({
     where: {
       sub: sub,
       group: {
-        name: groupName
-      },
-      NOT: {
-        group: {
-          initiative: {
-            code: Initiative.PCNS
-          }
-        }
+        name: { in: groupArray },
+        initiative: { code: initiativeCode }
       }
     }
   });

--- a/app/tests/unit/services/sso.spec.ts
+++ b/app/tests/unit/services/sso.spec.ts
@@ -36,7 +36,7 @@ afterEach(() => {
 });
 
 describe('searchIdirUsers', () => {
-  it('calls GET /${env}/idir/users with correct params and returns result', async () => {
+  it('calls GET /${env}/azure-idir/users with correct params and returns result', async () => {
     mockedConfig.get.mockReturnValue('TEST');
 
     mockedAxios.get.mockResolvedValueOnce({
@@ -46,7 +46,7 @@ describe('searchIdirUsers', () => {
 
     const response = await ssoService.searchIdirUsers(FAKE_PERSON);
 
-    expect(mockedAxios.get).toHaveBeenCalledWith('/TEST/idir/users', {
+    expect(mockedAxios.get).toHaveBeenCalledWith('/TEST/azure-idir/users', {
       params: FAKE_PERSON
     });
     expect(response).toStrictEqual({

--- a/app/tests/unit/services/yars.spec.ts
+++ b/app/tests/unit/services/yars.spec.ts
@@ -416,20 +416,19 @@ describe('subjectHasGroupName', () => {
   it('calls subject_group.count and returns true if count > 0', async () => {
     prismaTxMock.subject_group.count.mockResolvedValueOnce(1);
 
-    const response = await yarsService.subjectHasGroupName(prismaTxMock, 'sub', GroupName.NAVIGATOR);
+    const response = await yarsService.subjectHasGroupName(
+      prismaTxMock,
+      'sub',
+      [GroupName.NAVIGATOR],
+      Initiative.HOUSING
+    );
 
     expect(prismaTxMock.subject_group.count).toHaveBeenCalledWith({
       where: {
         sub: 'sub',
         group: {
-          name: GroupName.NAVIGATOR
-        },
-        NOT: {
-          group: {
-            initiative: {
-              code: Initiative.PCNS
-            }
-          }
+          name: { in: [GroupName.NAVIGATOR] },
+          initiative: { code: Initiative.HOUSING }
         }
       }
     });
@@ -440,24 +439,39 @@ describe('subjectHasGroupName', () => {
   it('calls subject_group.count and returns false if count <= 0', async () => {
     prismaTxMock.subject_group.count.mockResolvedValueOnce(0);
 
-    const response = await yarsService.subjectHasGroupName(prismaTxMock, 'sub', GroupName.NAVIGATOR);
+    const response = await yarsService.subjectHasGroupName(
+      prismaTxMock,
+      'sub',
+      [GroupName.NAVIGATOR],
+      Initiative.HOUSING
+    );
 
     expect(prismaTxMock.subject_group.count).toHaveBeenCalledWith({
       where: {
         sub: 'sub',
         group: {
-          name: GroupName.NAVIGATOR
-        },
-        NOT: {
-          group: {
-            initiative: {
-              code: Initiative.PCNS
-            }
-          }
+          name: { in: [GroupName.NAVIGATOR] },
+          initiative: { code: Initiative.HOUSING }
         }
       }
     });
 
     expect(response).toStrictEqual(false);
+  });
+
+  it('filters out undefined', async () => {
+    prismaTxMock.subject_group.count.mockResolvedValueOnce(1);
+
+    await yarsService.subjectHasGroupName(prismaTxMock, 'sub', [GroupName.NAVIGATOR, undefined], Initiative.HOUSING);
+
+    expect(prismaTxMock.subject_group.count).toHaveBeenCalledWith({
+      where: {
+        sub: 'sub',
+        group: {
+          name: { in: [GroupName.NAVIGATOR] },
+          initiative: { code: Initiative.HOUSING }
+        }
+      }
+    });
   });
 });

--- a/app/tests/unit/services/yars.spec.ts
+++ b/app/tests/unit/services/yars.spec.ts
@@ -416,12 +416,59 @@ describe('subjectHasGroupName', () => {
   it('calls subject_group.count and returns true if count > 0', async () => {
     prismaTxMock.subject_group.count.mockResolvedValueOnce(1);
 
-    const response = await yarsService.subjectHasGroupName(
-      prismaTxMock,
-      'sub',
-      [GroupName.NAVIGATOR],
-      Initiative.HOUSING
-    );
+    const response = await yarsService.subjectHasGroupName(prismaTxMock, 'sub', GroupName.NAVIGATOR);
+
+    expect(prismaTxMock.subject_group.count).toHaveBeenCalledWith({
+      where: {
+        sub: 'sub',
+        group: {
+          name: GroupName.NAVIGATOR
+        },
+        NOT: {
+          group: {
+            initiative: {
+              code: Initiative.PCNS
+            }
+          }
+        }
+      }
+    });
+
+    expect(response).toStrictEqual(true);
+  });
+
+  it('calls subject_group.count and returns false if count <= 0', async () => {
+    prismaTxMock.subject_group.count.mockResolvedValueOnce(0);
+
+    const response = await yarsService.subjectHasGroupName(prismaTxMock, 'sub', GroupName.NAVIGATOR);
+
+    expect(prismaTxMock.subject_group.count).toHaveBeenCalledWith({
+      where: {
+        sub: 'sub',
+        group: {
+          name: GroupName.NAVIGATOR
+        },
+        NOT: {
+          group: {
+            initiative: {
+              code: Initiative.PCNS
+            }
+          }
+        }
+      }
+    });
+
+    expect(response).toStrictEqual(false);
+  });
+});
+
+describe('subjectHasInitiativeGroupName', () => {
+  it('calls subject_group.count and returns true if count > 0', async () => {
+    prismaTxMock.subject_group.count.mockResolvedValueOnce(1);
+
+    const response = await yarsService.subjectHasInitiativeGroupName(prismaTxMock, 'sub', Initiative.HOUSING, [
+      GroupName.NAVIGATOR
+    ]);
 
     expect(prismaTxMock.subject_group.count).toHaveBeenCalledWith({
       where: {
@@ -439,12 +486,9 @@ describe('subjectHasGroupName', () => {
   it('calls subject_group.count and returns false if count <= 0', async () => {
     prismaTxMock.subject_group.count.mockResolvedValueOnce(0);
 
-    const response = await yarsService.subjectHasGroupName(
-      prismaTxMock,
-      'sub',
-      [GroupName.NAVIGATOR],
-      Initiative.HOUSING
-    );
+    const response = await yarsService.subjectHasInitiativeGroupName(prismaTxMock, 'sub', Initiative.HOUSING, [
+      GroupName.NAVIGATOR
+    ]);
 
     expect(prismaTxMock.subject_group.count).toHaveBeenCalledWith({
       where: {
@@ -462,7 +506,10 @@ describe('subjectHasGroupName', () => {
   it('filters out undefined', async () => {
     prismaTxMock.subject_group.count.mockResolvedValueOnce(1);
 
-    await yarsService.subjectHasGroupName(prismaTxMock, 'sub', [GroupName.NAVIGATOR, undefined], Initiative.HOUSING);
+    await yarsService.subjectHasInitiativeGroupName(prismaTxMock, 'sub', Initiative.HOUSING, [
+      GroupName.NAVIGATOR,
+      undefined
+    ]);
 
     expect(prismaTxMock.subject_group.count).toHaveBeenCalledWith({
       where: {

--- a/frontend/src/components/note/NoteForm.vue
+++ b/frontend/src/components/note/NoteForm.vue
@@ -341,9 +341,7 @@ onBeforeMount(async () => {
                     name="escalateToSupervisor"
                     :label="t('note.noteForm.escalateToSupervisor')"
                     :bold="false"
-                    :disabled="
-                      !editable || authzStore.isInGroup([GroupName.ADMIN, GroupName.DEVELOPER, GroupName.SUPERVISOR])
-                    "
+                    :disabled="!editable || authzStore.isInGroup([GroupName.ADMIN, GroupName.SUPERVISOR])"
                   />
                   <Checkbox
                     name="escalateToDirector"

--- a/frontend/src/components/projectCommon/ProjectTeamTab.vue
+++ b/frontend/src/components/projectCommon/ProjectTeamTab.vue
@@ -43,8 +43,6 @@ const isAdmin = computed(() => {
   // Navigator groups
   const adminGroups: GroupName[] = [GroupName.SUPERVISOR, GroupName.NAVIGATOR];
 
-  console.log(getContact.value);
-  console.log(getActivityContacts.value);
   return (
     (currentUserActivityContact.value && adminRoles.includes(currentUserActivityContact.value.role)) ||
     useAuthZStore().isInGroup(adminGroups)
@@ -294,6 +292,8 @@ onBeforeMount(() => {
   <div v-if="getActivityContacts">
     <ProjectTeamTable
       :activity-contacts="getActivityContacts"
+      :current-user-activity-contact="currentUserActivityContact"
+      :is-admin="isAdmin"
       @project-team-table:manage-user="onManageUserClick"
       @project-team-table:revoke-user="onRevokeUserClick"
     />

--- a/frontend/src/components/projectCommon/ProjectTeamTab.vue
+++ b/frontend/src/components/projectCommon/ProjectTeamTab.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { isAxiosError } from 'axios';
 import { storeToRefs } from 'pinia';
-import { onBeforeMount, ref } from 'vue';
+import { computed, onBeforeMount, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import ProjectTeamTable from './ProjectTeamTable.vue';
@@ -9,7 +9,8 @@ import ProjectTeamAddModal from './ProjectTeamAddModal.vue';
 import ProjectTeamManageModal from './ProjectTeamManageModal.vue';
 import { Button, useConfirm, useToast } from '@/lib/primevue';
 import { activityContactService, contactService } from '@/services';
-import { useAppStore, useProjectStore } from '@/store';
+import { useAppStore, useAuthZStore, useContactStore, useProjectStore } from '@/store';
+import { GroupName } from '@/utils/enums/application';
 import { ActivityContactRole } from '@/utils/enums/projectCommon';
 
 import type { Ref } from 'vue';
@@ -24,12 +25,31 @@ const toast = useToast();
 const appStore = useAppStore();
 const projectStore = useProjectStore();
 const { isInternal } = storeToRefs(appStore);
+const { getContact } = storeToRefs(useContactStore());
 const { getActivityContacts, getProject } = storeToRefs(projectStore);
 
 // State
 const addUserModalVisible: Ref<boolean> = ref(false);
 const manageUserModalVisible: Ref<boolean> = ref(false);
 const selectedContact: Ref<ActivityContact | undefined> = ref(undefined);
+
+const currentUserActivityContact = computed(() =>
+  getActivityContacts.value.find((ac) => ac.contactId === getContact.value?.contactId)
+);
+const isAdmin = computed(() => {
+  // Proponent roles
+  const adminRoles: ActivityContactRole[] = [ActivityContactRole.PRIMARY, ActivityContactRole.ADMIN];
+
+  // Navigator groups
+  const adminGroups: GroupName[] = [GroupName.SUPERVISOR, GroupName.NAVIGATOR];
+
+  console.log(getContact.value);
+  console.log(getActivityContacts.value);
+  return (
+    (currentUserActivityContact.value && adminRoles.includes(currentUserActivityContact.value.role)) ||
+    useAuthZStore().isInGroup(adminGroups)
+  );
+});
 
 // Actions
 function handleFailureToasts(failures: { contact: Contact; errorMessage: string }[]) {
@@ -262,6 +282,7 @@ onBeforeMount(() => {
     <div class="basis-1/6">
       <div class="flex justify-end">
         <Button
+          v-if="isAdmin"
           :label="isInternal ? t('projectTeamTab.addUserBtn') : t('projectTeamTab.addMemberBtn')"
           icon="pi pi-plus"
           outlined

--- a/frontend/src/components/projectCommon/ProjectTeamTable.vue
+++ b/frontend/src/components/projectCommon/ProjectTeamTable.vue
@@ -4,11 +4,11 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { Button, Column, DataTable } from '@/lib/primevue';
-import { useAppStore, useContactStore } from '@/store';
-import { ACTIVITY_CONTACT_ROLE_LIST } from '@/utils/constants/projectCommon';
+import { useAppStore, useAuthZStore, useContactStore } from '@/store';
 import { ActivityContactRole } from '@/utils/enums/projectCommon';
 
 import type { ActivityContact } from '@/types';
+import { GroupName } from '@/utils/enums/application';
 
 // Types
 enum TeamAction {
@@ -38,8 +38,16 @@ const currentUserActivityContact = computed(() =>
   activityContacts.find((ac) => ac.contactId === getContact.value?.contactId)
 );
 const isAdmin = computed(() => {
-  const adminRoles: ActivityContactRole[] = ACTIVITY_CONTACT_ROLE_LIST.filter((r) => r !== ActivityContactRole.MEMBER);
-  return currentUserActivityContact.value && adminRoles.includes(currentUserActivityContact.value.role);
+  // Proponent roles
+  const adminRoles: ActivityContactRole[] = [ActivityContactRole.PRIMARY, ActivityContactRole.ADMIN];
+
+  // Navigator groups
+  const adminGroups: GroupName[] = [GroupName.SUPERVISOR, GroupName.NAVIGATOR];
+
+  return (
+    (currentUserActivityContact.value && adminRoles.includes(currentUserActivityContact.value.role)) ||
+    useAuthZStore().isInGroup(adminGroups)
+  );
 });
 
 // Actions

--- a/frontend/src/components/projectCommon/ProjectTeamTable.vue
+++ b/frontend/src/components/projectCommon/ProjectTeamTable.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
-import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { Button, Column, DataTable } from '@/lib/primevue';
-import { useAppStore, useAuthZStore, useContactStore } from '@/store';
+import { useAppStore } from '@/store';
 import { ActivityContactRole } from '@/utils/enums/projectCommon';
 
 import type { ActivityContact } from '@/types';
-import { GroupName } from '@/utils/enums/application';
 
 // Types
 enum TeamAction {
@@ -17,8 +15,14 @@ enum TeamAction {
 }
 
 // Props
-const { activityContacts } = defineProps<{
+const {
+  activityContacts,
+  currentUserActivityContact = undefined,
+  isAdmin
+} = defineProps<{
   activityContacts: ActivityContact[];
+  currentUserActivityContact?: ActivityContact;
+  isAdmin: boolean;
 }>();
 
 // Composables
@@ -29,30 +33,11 @@ const emit = defineEmits(['projectTeamTable:manageUser', 'projectTeamTable:revok
 
 // Store
 const appStore = useAppStore();
-const contactStore = useContactStore();
 const { isInternal } = storeToRefs(appStore);
-const { getContact } = storeToRefs(contactStore);
-
-// State
-const currentUserActivityContact = computed(() =>
-  activityContacts.find((ac) => ac.contactId === getContact.value?.contactId)
-);
-const isAdmin = computed(() => {
-  // Proponent roles
-  const adminRoles: ActivityContactRole[] = [ActivityContactRole.PRIMARY, ActivityContactRole.ADMIN];
-
-  // Navigator groups
-  const adminGroups: GroupName[] = [GroupName.SUPERVISOR, GroupName.NAVIGATOR];
-
-  return (
-    (currentUserActivityContact.value && adminRoles.includes(currentUserActivityContact.value.role)) ||
-    useAuthZStore().isInGroup(adminGroups)
-  );
-});
 
 // Actions
 function isManageable(activityContact: ActivityContact, action: TeamAction) {
-  const isSelf = activityContact.contactId === currentUserActivityContact.value?.contactId;
+  const isSelf = activityContact.contactId === currentUserActivityContact?.contactId;
 
   // Cannot manage or revoke a primary contact
   if (activityContact.role === ActivityContactRole.PRIMARY) return false;

--- a/frontend/src/components/user/UserCreateModal.vue
+++ b/frontend/src/components/user/UserCreateModal.vue
@@ -103,7 +103,7 @@ watchEffect(async () => {
   const yarsGroups: Group[] = (await yarsService.getGroups(useAppStore().getInitiative)).data;
 
   const allowedGroups: GroupName[] = [GroupName.NAVIGATOR, GroupName.NAVIGATOR_READ_ONLY];
-  if (authzStore.isInGroup([GroupName.ADMIN, GroupName.DEVELOPER])) {
+  if (authzStore.isInGroup([GroupName.ADMIN])) {
     allowedGroups.unshift(GroupName.ADMIN, GroupName.SUPERVISOR);
   }
 

--- a/frontend/src/components/user/UserManageModal.vue
+++ b/frontend/src/components/user/UserManageModal.vue
@@ -30,7 +30,7 @@ watchEffect(async () => {
   const yarsGroups: Group[] = (await yarsService.getGroups(useAppStore().getInitiative)).data;
 
   const allowedGroups: GroupName[] = [GroupName.NAVIGATOR, GroupName.NAVIGATOR_READ_ONLY];
-  if (authzStore.isInGroup([GroupName.ADMIN, GroupName.DEVELOPER])) {
+  if (authzStore.isInGroup([GroupName.ADMIN])) {
     allowedGroups.unshift(GroupName.ADMIN, GroupName.SUPERVISOR);
   }
 

--- a/frontend/src/store/authzStore.ts
+++ b/frontend/src/store/authzStore.ts
@@ -202,7 +202,13 @@ export const useAuthZStore = defineStore('authz', () => {
     getGroups: computed(() => state.groups.value),
     getGroupOverride: computed(() => state.groupOverride.value),
     getInitiativeOverride: computed(() => state.initiativeOverride.value),
-    isInGroup: computed(() => (group: GroupName[]) => state.groups.value.some((x) => group.some((g) => g === x.name)))
+    isInGroup: computed(
+      () => (group: GroupName[]) =>
+        state.groups.value.some((g) => g.name === GroupName.DEVELOPER) ||
+        state.groups.value.some((x) =>
+          group.some((g) => x.initiativeCode === useAppStore().getInitiative && g === x.name)
+        )
+    )
   };
 
   // Actions

--- a/frontend/src/views/external/ProjectView.vue
+++ b/frontend/src/views/external/ProjectView.vue
@@ -384,10 +384,7 @@ onBeforeMount(async () => {
             v-if="isAdmin"
             :value="2"
           >
-            <ProjectTeamTab
-              v-if="projectStore.getProject"
-              :activity-id="projectStore.getProject.activityId"
-            />
+            <ProjectTeamTab v-if="projectStore.getProject" />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/frontend/src/views/internal/ProjectView.vue
+++ b/frontend/src/views/internal/ProjectView.vue
@@ -298,10 +298,7 @@ onBeforeMount(async () => {
         <ProjectEnquiryTab />
       </TabPanel>
       <TabPanel :value="6">
-        <ProjectTeamTab
-          v-if="getProject && !loading"
-          :activity-id="getProject.activityId"
-        />
+        <ProjectTeamTab v-if="getProject && !loading" />
       </TabPanel>
     </TabPanels>
   </Tabs>

--- a/frontend/src/views/internal/UserManagementView.vue
+++ b/frontend/src/views/internal/UserManagementView.vue
@@ -148,7 +148,7 @@ async function onProcessUserAccessRequest() {
 }
 
 function onRevoke(userAccessRequest: UserAccessRequest) {
-  const admin = authzStore.isInGroup([GroupName.ADMIN, GroupName.DEVELOPER]);
+  const admin = authzStore.isInGroup([GroupName.ADMIN]);
 
   const message = admin ? t('views.i.userManagementView.revokeAdmin1') : t('views.i.userManagementView.revokeAdmin2');
   const successMessage = admin

--- a/frontend/tests/unit/components/projectCommon/ProjectTeamTab.spec.ts
+++ b/frontend/tests/unit/components/projectCommon/ProjectTeamTab.spec.ts
@@ -57,7 +57,11 @@ const wrapperSettings = (zone = Zone.INTERNAL) => ({
       createTestingPinia({
         initialState: {
           app: { zone },
-          project: { project: { activityId: 'activity1' }, activityContacts: [] }
+          contact: { contact: mockContact },
+          project: {
+            project: { activityId: 'activity1' },
+            activityContacts: [{ ...mockActivityContact, role: ActivityContactRole.ADMIN }]
+          }
         }
       }),
       ConfirmationService,

--- a/frontend/tests/unit/components/projectCommon/ProjectTeamTable.spec.ts
+++ b/frontend/tests/unit/components/projectCommon/ProjectTeamTable.spec.ts
@@ -45,8 +45,17 @@ const activityContacts: ActivityContact[] = [
   { activityId: 'activity1', contactId: 'member', role: ActivityContactRole.MEMBER, contact: mockMemberContact }
 ];
 
-const wrapperSettings = (zone = Zone.INTERNAL, customContacts = activityContacts, currentUser = mockUserContact) => ({
-  props: { activityContacts: customContacts },
+const wrapperSettings = (
+  zone = Zone.INTERNAL,
+  customContacts = activityContacts,
+  currentUser = mockUserContact,
+  customActivityContact = activityContacts[0]
+) => ({
+  props: {
+    activityContacts: customContacts,
+    currentUserActivityContact: customActivityContact,
+    isAdmin: [ActivityContactRole.ADMIN, ActivityContactRole.PRIMARY].includes(customActivityContact.role)
+  },
   global: {
     plugins: [
       createTestingPinia({
@@ -113,7 +122,10 @@ describe('ProjectTeamTable.vue', () => {
 
   describe('Non-Admin View', () => {
     it('hides manage and revoke columns entirely if current user is not an Admin/Primary', async () => {
-      const wrapper = mount(ProjectTeamTable, wrapperSettings(Zone.INTERNAL, activityContacts, mockMemberContact));
+      const wrapper = mount(
+        ProjectTeamTable,
+        wrapperSettings(Zone.INTERNAL, activityContacts, mockMemberContact, activityContacts[3])
+      );
       await flushPromises();
 
       const manageBtns = wrapper.findAll(`button[aria-label="${t('projectTeamTable.headerManage')}"]`);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

This PR modifies the `isAdmin` check in `ProjectTeamTable.vue`, and the `requireActivityAdmin` middleware, to allow a specific subset of Navigator groups to have permissions to modify an activity even if they are not directly part of the project team. 

Two changes were made to user group checks to properly accommodate this, and fix permission leaks.
- `subjectHasGroupName` function in the `yars` service now requires an initiative code
- `authzStore.isInGroup` now takes initiative into consideration

https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-811

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->