### PR TITLE
fix: update PIES `ALLOWED` code mapping in PEACH parser

### DIFF
--- a/app/src/parsers/peach.ts
+++ b/app/src/parsers/peach.ts
@@ -180,13 +180,13 @@ const PROCESS_STATUS_MAPPINGS: Record<string, { stage: PermitStage; state: Permi
     stage: PermitStage.PENDING_DECISION,
     state: PermitState.IN_PROGRESS
   },
+  ALLOWED: {
+    stage: PermitStage.PENDING_DECISION,
+    state: PermitState.IN_PROGRESS
+  },
 
   // Post Decision
   // Approved
-  ALLOWED: {
-    stage: PermitStage.POST_DECISION,
-    state: PermitState.APPROVED
-  },
   OFFERED: {
     stage: PermitStage.POST_DECISION,
     state: PermitState.APPROVED

--- a/app/tests/unit/parsers/peach.test.ts
+++ b/app/tests/unit/parsers/peach.test.ts
@@ -119,8 +119,8 @@ describe('peachRecordParser', () => {
       expect(summary.submittedDate).toBeNull();
       expect(summary.submittedTime).toBeNull();
 
-      expect(summary.stage).toBe(PermitStage.POST_DECISION);
-      expect(summary.state).toBe(PermitState.APPROVED);
+      expect(summary.stage).toBe(PermitStage.PENDING_DECISION);
+      expect(summary.state).toBe(PermitState.IN_PROGRESS);
     });
 
     it('uses previous stage for terminal REJECTED and maps to Technical review/Rejected', () => {
@@ -389,8 +389,8 @@ describe('peachRecordParser', () => {
       expect(s2.decisionTime).toBe('12:00:00.000Z');
       expect(s2.submittedDate).toBeNull();
       expect(s2.submittedTime).toBeNull();
-      expect(s2.stage).toBe(PermitStage.POST_DECISION);
-      expect(s2.state).toBe(PermitState.APPROVED);
+      expect(s2.stage).toBe(PermitStage.PENDING_DECISION);
+      expect(s2.state).toBe(PermitState.IN_PROGRESS);
     });
 
     it('returns only the records that have mapped statuses', () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Changed PIES `ALLOWED` mapping in parser to map to `PENDING_DECISION - IN_PROGRESS` in PEACH parser.
Allowed wasn't meant to mean a "complete/accepted" permit, it's meant to me the decision has been allowed to move to "Issuance". The parser should reflect that,
[PADS-817](https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-817)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have ~~added~~ modified tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)