### PR TITLE
refactor: move CurrentContext and CurrentAuthorization to res.locals

### DIFF
--- a/app/src/controllers/accessRequest.ts
+++ b/app/src/controllers/accessRequest.ts
@@ -70,10 +70,10 @@ export const createUserAccessRequestController = async (
     const { accessRequest, user } = req.body;
 
     // Check if the requestee is an admin
-    const isAdmin = await isUserAdmin(tx, req.currentContext.initiative, req.currentAuthorization.groups);
+    const isAdmin = await isUserAdmin(tx, res.locals.currentContext.initiative, res.locals.currentAuthorization.groups);
 
     // Get all the groups for the current initiative
-    const groups = await getGroups(tx, req.currentContext.initiative);
+    const groups = await getGroups(tx, res.locals.currentContext.initiative);
 
     // Groups the current user can modify
     const userAllowedGroups = [GroupName.NAVIGATOR, GroupName.NAVIGATOR_READ_ONLY];
@@ -123,7 +123,7 @@ export const createUserAccessRequestController = async (
 
     if (isGroupUpdate) {
       // Remove current initiative groups
-      await removeUserGroups(tx, userResponse.sub, req.currentContext.initiative, accessUserGroups);
+      await removeUserGroups(tx, userResponse.sub, res.locals.currentContext.initiative, accessUserGroups);
 
       // Assign new groups
       await assignGroup(tx, userResponse.sub, accessRequest.groupId);
@@ -155,7 +155,7 @@ export const createUserAccessRequestController = async (
         };
       } else {
         // Remove current initiative groups
-        await removeUserGroups(tx, userResponse.sub, req.currentContext.initiative, accessUserGroups);
+        await removeUserGroups(tx, userResponse.sub, res.locals.currentContext.initiative, accessUserGroups);
       }
 
       updateComsPerms = true;
@@ -169,7 +169,7 @@ export const createUserAccessRequestController = async (
     // Assign new COMS permissions
     if (updateComsPerms) {
       try {
-        await assignPermissions(tx, req.currentContext, userResponse.sub);
+        await assignPermissions(tx, res.locals.currentContext, userResponse.sub);
       } catch (e) {
         if (e instanceof Error) log.warn(e.message);
         if (e instanceof Problem) log.warn(e.detail);
@@ -187,7 +187,7 @@ export const processUserAccessRequestController = async (
   res: Response
 ) => {
   await transactionWrapper<void>(async (tx: PrismaTransactionClient) => {
-    const accessRequest = await getAccessRequest(tx, req.currentContext.initiative, req.params.accessRequestId);
+    const accessRequest = await getAccessRequest(tx, res.locals.currentContext.initiative, req.params.accessRequestId);
 
     if (accessRequest) {
       const userResponse = await readUser(tx, accessRequest.userId);
@@ -214,14 +214,14 @@ export const processUserAccessRequestController = async (
             await assignGroup(tx, userResponse.sub, correspondingGlobalGroup.groupId);
           } else {
             // Remove all user groups for the initiative
-            await removeUserGroups(tx, userResponse.sub, req.currentContext.initiative, userGroups);
+            await removeUserGroups(tx, userResponse.sub, res.locals.currentContext.initiative, userGroups);
           }
 
           // Update access request status
           await updateAccessRequest(tx, { status: AccessRequestStatus.APPROVED }, accessRequest.accessRequestId);
 
           // Assign new COMS permissions
-          await assignPermissions(tx, req.currentContext, userResponse.sub);
+          await assignPermissions(tx, res.locals.currentContext, userResponse.sub);
         } else {
           await updateAccessRequest(tx, { status: AccessRequestStatus.REJECTED }, accessRequest.accessRequestId);
         }
@@ -236,7 +236,7 @@ export const processUserAccessRequestController = async (
 
 export const getAccessRequestsController = async (req: Request, res: Response) => {
   const response = await transactionWrapper<AccessRequest[]>(async (tx: PrismaTransactionClient) => {
-    return await getAccessRequests(tx, req.currentContext.initiative);
+    return await getAccessRequests(tx, res.locals.currentContext.initiative);
   });
   res.status(200).json(response);
 };

--- a/app/src/controllers/activityContact.ts
+++ b/app/src/controllers/activityContact.ts
@@ -74,14 +74,14 @@ export const createActivityContactController = async (
   const response = await transactionWrapper<ActivityContact>(async (tx: PrismaTransactionClient) => {
     // If the PRIMARY role is being given to another user, make any pre adjustments
     if (req.body.role === ActivityContactRole.PRIMARY)
-      await verifyPrimaryChange(tx, req.params.activityId, req.currentAuthorization, req.currentContext);
+      await verifyPrimaryChange(tx, req.params.activityId, res.locals.currentAuthorization, res.locals.currentContext);
 
     const newContact = await createActivityContact(tx, req.params.activityId, req.params.contactId, req.body.role);
 
     const { templateParams, navEmail } = await getTeamMemberEmailTemplateData(
       tx,
-      req.currentContext.initiative,
-      req.currentContext.userId,
+      res.locals.currentContext.initiative,
+      res.locals.currentContext.userId,
       req.params.activityId,
       newContact.contact!
     );
@@ -126,8 +126,8 @@ export const deleteActivityContactController = async (
 
     const { templateParams, navEmail } = await getTeamMemberEmailTemplateData(
       tx,
-      req.currentContext.initiative,
-      req.currentContext.userId,
+      res.locals.currentContext.initiative,
+      res.locals.currentContext.userId,
       req.params.activityId,
       ac.contact!
     );
@@ -171,15 +171,20 @@ export const updateActivityContactController = async (
       // If the PRIMARY role is being given to another user, make any pre adjustments
       let demoted: ActivityContact | undefined;
       if (req.body.role === ActivityContactRole.PRIMARY) {
-        demoted = await verifyPrimaryChange(tx, req.params.activityId, req.currentAuthorization, req.currentContext);
+        demoted = await verifyPrimaryChange(
+          tx,
+          req.params.activityId,
+          res.locals.currentAuthorization,
+          res.locals.currentContext
+        );
       }
 
       const updated = await updateActivityContact(tx, req.params.activityId, req.params.contactId, req.body.role);
 
       const { templateParams, navEmail } = await getTeamMemberEmailTemplateData(
         tx,
-        req.currentContext.initiative,
-        req.currentContext.userId,
+        res.locals.currentContext.initiative,
+        res.locals.currentContext.userId,
         req.params.activityId,
         updated.contact!
       );

--- a/app/src/controllers/ats.ts
+++ b/app/src/controllers/ats.ts
@@ -8,10 +8,10 @@ export const createATSClientController = async (
   req: Request<never, never, ATSClientResource, never>,
   res: Response
 ) => {
-  const identityProvider = req.currentContext?.tokenPayload?.identity_provider.toUpperCase();
+  const identityProvider = res.locals.currentContext?.tokenPayload?.identity_provider.toUpperCase();
   const atsClient = req.body;
   // Set the createdBy field to current user with \\ as the separator for the domain and username to match ATS DB
-  atsClient.createdBy = `${identityProvider}\\${getCurrentUsername(req.currentContext)}`;
+  atsClient.createdBy = `${identityProvider}\\${getCurrentUsername(res.locals.currentContext)}`;
   const response = await createATSClient(atsClient);
   res.status(response.status).json(response.data);
 };
@@ -20,10 +20,10 @@ export const createATSEnquiryController = async (
   req: Request<never, never, ATSEnquiryResource, never>,
   res: Response
 ) => {
-  const identityProvider = req.currentContext?.tokenPayload?.identity_provider.toUpperCase();
+  const identityProvider = res.locals.currentContext?.tokenPayload?.identity_provider.toUpperCase();
   const atsEnquiry = req.body;
   // Set the createdBy field to current user with \\ as the separator for the domain and username to match ATS DB
-  atsEnquiry.createdBy = `${identityProvider}\\${getCurrentUsername(req.currentContext)}`;
+  atsEnquiry.createdBy = `${identityProvider}\\${getCurrentUsername(res.locals.currentContext)}`;
   const response = await createATSEnquiry(atsEnquiry);
   res.status(response.status).json(response.data);
 };

--- a/app/src/controllers/contact.ts
+++ b/app/src/controllers/contact.ts
@@ -15,7 +15,7 @@ import { addDashesToUuid, hasIdentity, isTruthy, mixedQueryToArray } from '../ut
 
 import type { Request, Response } from 'express';
 import type { PrismaTransactionClient } from '../db/database.ts';
-import type { Contact, ContactSearchParameters } from '../types/index.ts';
+import type { Contact, ContactSearchParameters, LocalContext } from '../types/index.ts';
 
 export const deleteContactController = async (req: Request<{ contactId: string }>, res: Response) => {
   const contactId = req.params.contactId;
@@ -27,7 +27,7 @@ export const deleteContactController = async (req: Request<{ contactId: string }
 
 export const getContactController = async (
   req: Request<{ contactId: string }, never, never, { includeActivities?: boolean }>,
-  res: Response
+  res: Response<Contact>
 ) => {
   const response = await transactionWrapper<Contact>(async (tx: PrismaTransactionClient) => {
     const contactId = req.params.contactId;
@@ -38,10 +38,10 @@ export const getContactController = async (
 };
 
 // Get current user's contact information
-export const getCurrentUserContactController = async (req: Request<never, never, never, never>, res: Response) => {
+export const getCurrentUserContactController = async (req: Request, res: Response<Contact, LocalContext>) => {
   const response = await transactionWrapper<Contact[]>(async (tx: PrismaTransactionClient) => {
     return await searchContacts(tx, {
-      userId: [req.currentContext.userId!]
+      userId: [res.locals.currentContext.userId!]
     });
   });
   res.status(200).json(response[0]);
@@ -49,10 +49,11 @@ export const getCurrentUserContactController = async (req: Request<never, never,
 
 export const matchContactsController = async (
   req: Request<never, never, ContactSearchParameters, never>,
-  res: Response
+  res: Response<Contact[], LocalContext>
 ) => {
   const response = await transactionWrapper<Contact[]>(async (tx: PrismaTransactionClient) => {
-    if (hasIdentity(IdentityProviderKind.AZUREIDIR, req.currentContext)) return await matchContacts(tx, req.body);
+    if (hasIdentity(IdentityProviderKind.AZUREIDIR, res.locals.currentContext))
+      return await matchContacts(tx, req.body);
     return await matchContactsExact(tx, req.body);
   });
   res.status(200).json(response);
@@ -60,7 +61,7 @@ export const matchContactsController = async (
 
 export const searchContactsController = async (
   req: Request<never, never, ContactSearchParameters | undefined, never>,
-  res: Response
+  res: Response<Contact[]>
 ) => {
   const contactIds = mixedQueryToArray(req.body?.contactId);
   const userIds = mixedQueryToArray(req.body?.userId);
@@ -80,10 +81,13 @@ export const searchContactsController = async (
   res.status(200).json(response);
 };
 
-export const upsertContactController = async (req: Request<never, never, Contact, never>, res: Response) => {
+export const upsertContactController = async (
+  req: Request<never, never, Contact, never>,
+  res: Response<Contact, LocalContext>
+) => {
   const contact = { ...req.body, contactId: req.body.contactId ?? uuidv4() };
   const response = await transactionWrapper<Contact[]>(async (tx: PrismaTransactionClient) => {
-    return await upsertContacts(tx, [{ ...contact, ...generateUpdateStamps(req.currentContext) }]);
+    return await upsertContacts(tx, [{ ...contact, ...generateUpdateStamps(res.locals.currentContext) }]);
   });
   res.status(200).json(response[0]);
 };

--- a/app/src/controllers/document.ts
+++ b/app/src/controllers/document.ts
@@ -23,7 +23,7 @@ export const createDocumentController = async (
       req.body.filename,
       req.body.mimeType,
       req.body.filesize,
-      generateCreateStamps(req.currentContext)
+      generateCreateStamps(res.locals.currentContext)
     );
 
     let createdByFullName: string | undefined;

--- a/app/src/controllers/electrificationProject.ts
+++ b/app/src/controllers/electrificationProject.ts
@@ -149,12 +149,12 @@ export const createElectrificationProjectController = async (
   } as ElectrificationProjectIntake;
 
   const result = await transactionWrapper<ElectrificationProject>(async (tx: PrismaTransactionClient) => {
-    const electrificationProject = await generateElectrificationProjectData(tx, req.body, req.currentContext);
+    const electrificationProject = await generateElectrificationProjectData(tx, req.body, res.locals.currentContext);
 
     // Create new electrification project
     return await createElectrificationProject(tx, {
       ...electrificationProject,
-      ...generateCreateStamps(req.currentContext)
+      ...generateCreateStamps(res.locals.currentContext)
     });
   });
 
@@ -170,9 +170,9 @@ export const deleteElectrificationProjectController = async (
     await deleteElectrificationProject(
       tx,
       req.params.electrificationProjectId,
-      generateDeleteStamps(req.currentContext)
+      generateDeleteStamps(res.locals.currentContext)
     );
-    await deleteActivity(tx, project.activityId, generateDeleteStamps(req.currentContext));
+    await deleteActivity(tx, project.activityId, generateDeleteStamps(res.locals.currentContext));
   });
   res.status(204).end();
 };
@@ -246,12 +246,12 @@ export const submitElectrificationProjectDraftController = async (
 ) => {
   const result = await transactionWrapper<ElectrificationProject & { contact: Contact }>(
     async (tx: PrismaTransactionClient) => {
-      const electrificationProject = await generateElectrificationProjectData(tx, req.body, req.currentContext);
+      const electrificationProject = await generateElectrificationProjectData(tx, req.body, res.locals.currentContext);
 
       // Create new electrification project
       const data = await createElectrificationProject(tx, {
         ...electrificationProject,
-        ...generateCreateStamps(req.currentContext)
+        ...generateCreateStamps(res.locals.currentContext)
       });
 
       // Delete old draft
@@ -259,7 +259,7 @@ export const submitElectrificationProjectDraftController = async (
 
       // Update the contact
       const contactResponse = await upsertContacts(tx, [
-        { ...req.body.contact, ...generateUpdateStamps(req.currentContext) }
+        { ...req.body.contact, ...generateUpdateStamps(res.locals.currentContext) }
       ]);
 
       return { ...data, contact: contactResponse[0] };
@@ -277,12 +277,12 @@ export const upsertElectrificationProjectDraftController = async (req: Request<n
       // Update draft
       return await updateDraft(tx, {
         ...req.body,
-        ...generateUpdateStamps(req.currentContext)
+        ...generateUpdateStamps(res.locals.currentContext)
       });
     } else {
       // Create new draft
       const activityId = (
-        await createActivity(tx, Initiative.ELECTRIFICATION, generateCreateStamps(req.currentContext))
+        await createActivity(tx, Initiative.ELECTRIFICATION, generateCreateStamps(res.locals.currentContext))
       )?.activityId;
 
       const draft = await createDraft(tx, {
@@ -290,13 +290,13 @@ export const upsertElectrificationProjectDraftController = async (req: Request<n
         activityId: activityId,
         draftCode: DraftCode.ELECTRIFICATION_PROJECT,
         data: req.body.data,
-        ...generateCreateStamps(req.currentContext),
+        ...generateCreateStamps(res.locals.currentContext),
         ...generateNullUpdateStamps(),
         ...generateNullDeleteStamps()
       });
 
       // Update the contact and link to activity
-      const contacts = await searchContacts(tx, { userId: [req.currentContext.userId!] });
+      const contacts = await searchContacts(tx, { userId: [res.locals.currentContext.userId!] });
       if (contacts[0])
         await createActivityContact(tx, draft.activityId, contacts[0].contactId, ActivityContactRole.PRIMARY);
 
@@ -320,7 +320,7 @@ export const updateElectrificationProjectController = async (
       tx,
       {
         ...req.body,
-        ...generateUpdateStamps(req.currentContext)
+        ...generateUpdateStamps(res.locals.currentContext)
       },
       req.params.electrificationProjectId
     );

--- a/app/src/controllers/enquiry.ts
+++ b/app/src/controllers/enquiry.ts
@@ -69,7 +69,7 @@ export const createEnquiryController = async (req: Request<never, never, Enquiry
   req.body ??= {} as EnquiryIntake;
 
   const result = await transactionWrapper<Enquiry & { contact: Contact }>(async (tx: PrismaTransactionClient) => {
-    const enquiry = await generateEnquiryData(tx, req.body, req.currentContext);
+    const enquiry = await generateEnquiryData(tx, req.body, res.locals.currentContext);
 
     // Create new enquiry
     const data = await createEnquiry(tx, {
@@ -79,18 +79,18 @@ export const createEnquiryController = async (req: Request<never, never, Enquiry
       atsClientId: null,
       atsEnquiryId: null,
       submittedMethod: EnquirySubmittedMethod.PCNS,
-      ...generateCreateStamps(req.currentContext),
+      ...generateCreateStamps(res.locals.currentContext),
       ...generateNullUpdateStamps()
     });
 
     // Update the contact
     const contactResponse = await upsertContacts(tx, [
-      { ...req.body.contact, ...generateUpdateStamps(req.currentContext) }
+      { ...req.body.contact, ...generateUpdateStamps(res.locals.currentContext) }
     ]);
 
     // Create additional activity_contact links if the enquiry is related to a project
     if (data.relatedActivityId) {
-      const currentContact = await searchContacts(tx, { userId: [req.currentContext.userId!] });
+      const currentContact = await searchContacts(tx, { userId: [res.locals.currentContext.userId!] });
 
       const relatedContacts = (await listActivityContacts(tx, data.relatedActivityId)).filter(
         (x) => x.contactId != currentContact[0].contactId
@@ -106,7 +106,7 @@ export const createEnquiryController = async (req: Request<never, never, Enquiry
     return { ...data, contact: contactResponse[0] };
   });
 
-  await emailEnquiryConfirmation(result, req.currentContext.initiative, req.body.relatedActivityId);
+  await emailEnquiryConfirmation(result, res.locals.currentContext.initiative, req.body.relatedActivityId);
   res.status(201).json(result);
 };
 
@@ -172,8 +172,8 @@ async function emailEnquiryConfirmation(
 export const deleteEnquiryController = async (req: Request<{ enquiryId: string }>, res: Response) => {
   await transactionWrapper<void>(async (tx: PrismaTransactionClient) => {
     const enquiry = await getEnquiry(tx, req.params.enquiryId);
-    await deleteEnquiry(tx, req.params.enquiryId, generateDeleteStamps(req.currentContext));
-    await deleteActivity(tx, enquiry.activityId, generateDeleteStamps(req.currentContext));
+    await deleteEnquiry(tx, req.params.enquiryId, generateDeleteStamps(res.locals.currentContext));
+    await deleteActivity(tx, enquiry.activityId, generateDeleteStamps(res.locals.currentContext));
   });
   res.status(204).end();
 };
@@ -211,7 +211,7 @@ export const searchEnquiriesController = async (
         ...req.body,
         includeUser: isTruthy(req.body?.includeUser)
       },
-      req.currentContext.initiative
+      res.locals.currentContext.initiative
     );
   });
 
@@ -227,7 +227,7 @@ export const updateEnquiryController = async (
       tx,
       {
         ...req.body,
-        ...generateUpdateStamps(req.currentContext)
+        ...generateUpdateStamps(res.locals.currentContext)
       },
       req.params.enquiryId
     );

--- a/app/src/controllers/generalProject.ts
+++ b/app/src/controllers/generalProject.ts
@@ -246,13 +246,13 @@ export const createGeneralProjectController = async (
     const { generalProject, appliedPermits, investigatePermits } = await generateGeneralProjectData(
       tx,
       req.body,
-      req.currentContext
+      res.locals.currentContext
     );
 
     // Create new general project
     const data = await createGeneralProject(tx, {
       ...generalProject,
-      ...generateCreateStamps(req.currentContext)
+      ...generateCreateStamps(res.locals.currentContext)
     });
 
     // Create each permit and tracking IDs
@@ -277,8 +277,8 @@ export const createGeneralProjectController = async (
 export const deleteGeneralProjectController = async (req: Request<{ generalProjectId: string }>, res: Response) => {
   await transactionWrapper<void>(async (tx: PrismaTransactionClient) => {
     const project = await getGeneralProject(tx, req.params.generalProjectId);
-    await deleteGeneralProject(tx, req.params.generalProjectId, generateDeleteStamps(req.currentContext));
-    await deleteActivity(tx, project.activityId, generateDeleteStamps(req.currentContext));
+    await deleteGeneralProject(tx, req.params.generalProjectId, generateDeleteStamps(res.locals.currentContext));
+    await deleteActivity(tx, project.activityId, generateDeleteStamps(res.locals.currentContext));
   });
 
   res.status(204).end();
@@ -352,13 +352,13 @@ export const submitGeneralProjectDraftController = async (
       const { generalProject, appliedPermits, investigatePermits } = await generateGeneralProjectData(
         tx,
         req.body,
-        req.currentContext
+        res.locals.currentContext
       );
 
       // Create new general project
       const data = await createGeneralProject(tx, {
         ...generalProject,
-        ...generateCreateStamps(req.currentContext)
+        ...generateCreateStamps(res.locals.currentContext)
       });
 
       // Create each permit and tracking IDs
@@ -379,7 +379,7 @@ export const submitGeneralProjectDraftController = async (
 
       // Update the contact
       const contactResponse = await upsertContacts(tx, [
-        { ...req.body.contact, ...generateUpdateStamps(req.currentContext) }
+        { ...req.body.contact, ...generateUpdateStamps(res.locals.currentContext) }
       ]);
 
       return { ...data, contact: contactResponse[0] };
@@ -398,11 +398,11 @@ export const upsertGeneralProjectDraftController = async (req: Request<never, ne
       // Update draft
       return await updateDraft(tx, {
         ...req.body,
-        ...generateUpdateStamps(req.currentContext)
+        ...generateUpdateStamps(res.locals.currentContext)
       });
     } else {
       // Create new draft
-      const activityId = (await createActivity(tx, Initiative.GENERAL, generateCreateStamps(req.currentContext)))
+      const activityId = (await createActivity(tx, Initiative.GENERAL, generateCreateStamps(res.locals.currentContext)))
         ?.activityId;
 
       const draft = await createDraft(tx, {
@@ -410,13 +410,13 @@ export const upsertGeneralProjectDraftController = async (req: Request<never, ne
         activityId: activityId,
         draftCode: DraftCode.GENERAL_PROJECT,
         data: req.body.data,
-        ...generateCreateStamps(req.currentContext),
+        ...generateCreateStamps(res.locals.currentContext),
         ...generateNullUpdateStamps(),
         ...generateNullDeleteStamps()
       });
 
       // Link contact to activity
-      const contacts = await searchContacts(tx, { userId: [req.currentContext.userId!] });
+      const contacts = await searchContacts(tx, { userId: [res.locals.currentContext.userId!] });
       if (contacts[0]) {
         await createActivityContact(tx, draft.activityId, contacts[0].contactId, ActivityContactRole.PRIMARY);
       }
@@ -437,7 +437,7 @@ export const updateGeneralProjectController = async (
       tx,
       {
         ...req.body,
-        ...generateUpdateStamps(req.currentContext)
+        ...generateUpdateStamps(res.locals.currentContext)
       },
       req.params.generalProjectId
     );

--- a/app/src/controllers/housingProject.ts
+++ b/app/src/controllers/housingProject.ts
@@ -314,13 +314,13 @@ export const createHousingProjectController = async (
     const { housingProject, appliedPermits, investigatePermits } = await generateHousingProjectData(
       tx,
       req.body,
-      req.currentContext
+      res.locals.currentContext
     );
 
     // Create new housing project
     const data = await createHousingProject(tx, {
       ...housingProject,
-      ...generateCreateStamps(req.currentContext)
+      ...generateCreateStamps(res.locals.currentContext)
     });
 
     // Create each permit and tracking IDs
@@ -345,8 +345,8 @@ export const createHousingProjectController = async (
 export const deleteHousingProjectController = async (req: Request<{ housingProjectId: string }>, res: Response) => {
   await transactionWrapper<void>(async (tx: PrismaTransactionClient) => {
     const project = await getHousingProject(tx, req.params.housingProjectId);
-    await deleteHousingProject(tx, req.params.housingProjectId, generateDeleteStamps(req.currentContext));
-    await deleteActivity(tx, project.activityId, generateDeleteStamps(req.currentContext));
+    await deleteHousingProject(tx, req.params.housingProjectId, generateDeleteStamps(res.locals.currentContext));
+    await deleteActivity(tx, project.activityId, generateDeleteStamps(res.locals.currentContext));
   });
 
   res.status(204).end();
@@ -420,13 +420,13 @@ export const submitHousingProjectDraftController = async (
       const { housingProject, appliedPermits, investigatePermits } = await generateHousingProjectData(
         tx,
         req.body,
-        req.currentContext
+        res.locals.currentContext
       );
 
       // Create new housing project
       const data = await createHousingProject(tx, {
         ...housingProject,
-        ...generateCreateStamps(req.currentContext)
+        ...generateCreateStamps(res.locals.currentContext)
       });
 
       // Create each permit and tracking IDs
@@ -447,7 +447,7 @@ export const submitHousingProjectDraftController = async (
 
       // Update the contact
       const contactResponse = await upsertContacts(tx, [
-        { ...req.body.contact, ...generateUpdateStamps(req.currentContext) }
+        { ...req.body.contact, ...generateUpdateStamps(res.locals.currentContext) }
       ]);
 
       return { ...data, contact: contactResponse[0] };
@@ -465,11 +465,11 @@ export const upsertHousingProjectDraftController = async (req: Request<never, ne
       // Update draft
       return await updateDraft(tx, {
         ...req.body,
-        ...generateUpdateStamps(req.currentContext)
+        ...generateUpdateStamps(res.locals.currentContext)
       });
     } else {
       // Create new draft
-      const activityId = (await createActivity(tx, Initiative.HOUSING, generateCreateStamps(req.currentContext)))
+      const activityId = (await createActivity(tx, Initiative.HOUSING, generateCreateStamps(res.locals.currentContext)))
         ?.activityId;
 
       const draft = await createDraft(tx, {
@@ -477,13 +477,13 @@ export const upsertHousingProjectDraftController = async (req: Request<never, ne
         activityId: activityId,
         draftCode: DraftCode.HOUSING_PROJECT,
         data: req.body.data,
-        ...generateCreateStamps(req.currentContext),
+        ...generateCreateStamps(res.locals.currentContext),
         ...generateNullUpdateStamps(),
         ...generateNullDeleteStamps()
       });
 
       // Link contact to activity
-      const contacts = await searchContacts(tx, { userId: [req.currentContext.userId!] });
+      const contacts = await searchContacts(tx, { userId: [res.locals.currentContext.userId!] });
       if (contacts[0]) {
         await createActivityContact(tx, draft.activityId, contacts[0].contactId, ActivityContactRole.PRIMARY);
       }
@@ -510,7 +510,7 @@ export const updateHousingProjectController = async (
           req.body.financiallySupportedNonProfit,
           req.body.financiallySupportedHousingCoop
         ].includes(BasicResponse.YES),
-        ...generateUpdateStamps(req.currentContext)
+        ...generateUpdateStamps(res.locals.currentContext)
       },
       req.params.housingProjectId
     );

--- a/app/src/controllers/noteHistory.ts
+++ b/app/src/controllers/noteHistory.ts
@@ -33,7 +33,7 @@ import { bringForwardEnquiryNotificationTemplate, bringForwardProjectNotificatio
 
 import type { Request, Response } from 'express';
 import type { PrismaTransactionClient } from '../db/database.ts';
-import type { BringForward, Note, NoteHistory, User } from '../types/index.ts';
+import type { BringForward, LocalContext, Note, NoteHistory, User } from '../types/index.ts';
 
 /**
  * Create a new note history and add the given note to it
@@ -51,14 +51,14 @@ export const createNoteHistoryController = async (
       const historyRes = await createNoteHistory(tx, {
         ...history,
         noteHistoryId: uuidv4(),
-        ...generateCreateStamps(req.currentContext)
+        ...generateCreateStamps(res.locals.currentContext)
       });
 
       const noteRes = await createNote(tx, {
         noteId: uuidv4(),
         noteHistoryId: historyRes.noteHistoryId,
         note: note,
-        ...generateCreateStamps(req.currentContext),
+        ...generateCreateStamps(res.locals.currentContext),
         ...generateNullUpdateStamps(),
         ...generateNullDeleteStamps()
       });
@@ -77,7 +77,7 @@ export const createNoteHistoryController = async (
  */
 export const deleteNoteHistoryController = async (req: Request<{ noteHistoryId: string }>, res: Response) => {
   await transactionWrapper<void>(async (tx: PrismaTransactionClient) => {
-    await deleteNoteHistory(tx, req.params.noteHistoryId, generateDeleteStamps(req.currentContext));
+    await deleteNoteHistory(tx, req.params.noteHistoryId, generateDeleteStamps(res.locals.currentContext));
   });
 
   res.status(204).end();
@@ -90,7 +90,7 @@ export const listBringForwardController = async (
   const response = await transactionWrapper<BringForward[]>(async (tx: PrismaTransactionClient) => {
     const history: NoteHistory[] = await listBringForward(
       tx,
-      req.currentContext.initiative,
+      res.locals.currentContext.initiative,
       req.query.bringForwardState
     );
 
@@ -176,7 +176,7 @@ export const listNoteHistoryController = async (req: Request<{ activityId: strin
   });
 
   // Only return notes flagged as shown when called by proponent
-  if (req.currentAuthorization?.attributes.includes('scope:self')) {
+  if (res.locals.currentAuthorization?.attributes.includes('scope:self')) {
     const filtered = response.filter((x) => x.shownToProponent);
     res.status(200).json(filtered);
   } else {
@@ -192,14 +192,14 @@ export const listNoteHistoryController = async (req: Request<{ activityId: strin
  */
 export const updateNoteHistoryController = async (
   req: Request<{ noteHistoryId: string }, never, NoteHistory & { note: string | undefined; resource: Resource }>,
-  res: Response
+  res: Response<NoteHistory, LocalContext>
 ) => {
   const { note, resource, ...history } = req.body;
   const response = await transactionWrapper<NoteHistory>(async (tx: PrismaTransactionClient) => {
     await updateNoteHistory(tx, {
       ...history,
       noteHistoryId: req.params.noteHistoryId,
-      ...generateUpdateStamps(req.currentContext)
+      ...generateUpdateStamps(res.locals.currentContext)
     });
 
     if (note) {
@@ -207,7 +207,7 @@ export const updateNoteHistoryController = async (
         noteHistoryId: req.params.noteHistoryId,
         noteId: uuidv4(),
         note: note,
-        ...generateCreateStamps(req.currentContext),
+        ...generateCreateStamps(res.locals.currentContext),
         ...generateNullUpdateStamps(),
         ...generateNullDeleteStamps()
       });
@@ -216,8 +216,8 @@ export const updateNoteHistoryController = async (
     return await getNoteHistory(tx, req.params.noteHistoryId);
   });
 
-  const isNavigator = !!req.currentAuthorization?.groups.some((group) => group.name === GroupName.NAVIGATOR);
-  if (isNavigator) await emailBringForwardNotification(response, req.currentContext.initiative, resource);
+  const isNavigator = !!res.locals.currentAuthorization?.groups.some((group) => group.name === GroupName.NAVIGATOR);
+  if (isNavigator) await emailBringForwardNotification(response, res.locals.currentContext.initiative, resource);
 
   res.status(200).json(response);
 };

--- a/app/src/controllers/permit.ts
+++ b/app/src/controllers/permit.ts
@@ -132,11 +132,11 @@ export const searchPermitsController = async (
   const response = await transactionWrapper<{ permits: Permit[]; totalRecords: number }>(
     async (tx: PrismaTransactionClient) => {
       // Validate it's not PCNS
-      if (req.currentContext.initiative === Initiative.PCNS) {
+      if (res.locals.currentContext.initiative === Initiative.PCNS) {
         throw new Problem(400, { detail: 'Invalid initiative' });
       }
 
-      return await searchPermitsPaginated(tx, req.currentContext.initiative!, req.query); // nosonar
+      return await searchPermitsPaginated(tx, res.locals.currentContext.initiative!, req.query); // nosonar
     }
   );
   res.status(200).json(response);
@@ -246,8 +246,8 @@ export const sendPermitUpdateNotifications = async (
 
 export const upsertPermitController = async (req: Request<never, never, Permit>, res: Response) => {
   const response = await transactionWrapper<Permit>(async (tx: PrismaTransactionClient) => {
-    const createStamps = generateCreateStamps(req.currentContext);
-    const updateStamps = generateUpdateStamps(req.currentContext);
+    const createStamps = generateCreateStamps(res.locals.currentContext);
+    const updateStamps = generateUpdateStamps(res.locals.currentContext);
 
     // Add permit ID and stamp data if necessary
     const permitData: Permit = {

--- a/app/src/controllers/roadmap.ts
+++ b/app/src/controllers/roadmap.ts
@@ -39,12 +39,12 @@ export const sendRoadmapController = async (
   if (req.body.selectedFileIds?.length) {
     const attachments: EmailAttachment[] = [];
 
-    if (req.currentContext?.bearerToken) {
+    if (res.locals.currentContext?.bearerToken) {
       // Attempt to get the requested documents from COMS
       // If succesful it is converted to base64 encoding and added to the attachment list
       const objectPromises = req.body.selectedFileIds.map(async (id) => {
-        const { status, headers, data } = await getObject(req.currentContext.bearerToken!, id);
-        const searchResponse = await searchObject(req.currentContext.bearerToken!, id);
+        const { status, headers, data } = await getObject(res.locals.currentContext.bearerToken!, id);
+        const searchResponse = await searchObject(res.locals.currentContext.bearerToken!, id);
 
         if (status === 200 && searchResponse.data[0]) {
           const filename = searchResponse.data[0].name;
@@ -93,7 +93,7 @@ export const sendRoadmapController = async (
         escalateToDirector: false,
         escalationType: null,
         shownToProponent: false,
-        ...generateCreateStamps(req.currentContext),
+        ...generateCreateStamps(res.locals.currentContext),
         ...generateNullUpdateStamps(),
         ...generateNullDeleteStamps()
       });
@@ -102,7 +102,7 @@ export const sendRoadmapController = async (
         noteId: uuidv4(),
         noteHistoryId: noteHistory.noteHistoryId,
         note: noteBody,
-        ...generateCreateStamps(req.currentContext),
+        ...generateCreateStamps(res.locals.currentContext),
         ...generateNullUpdateStamps(),
         ...generateNullDeleteStamps()
       });

--- a/app/src/controllers/yars.ts
+++ b/app/src/controllers/yars.ts
@@ -45,15 +45,15 @@ export const listPermissionsController = async (
 
 export const listSubjectPermissionsController = async (req: Request, res: Response) => {
   const response = await transactionWrapper(async (tx: PrismaTransactionClient) => {
-    if (!req.currentContext.tokenPayload?.sub) throw new Problem(500, { detail: 'Unable to read token sub' });
+    if (!res.locals.currentContext.tokenPayload?.sub) throw new Problem(500, { detail: 'Unable to read token sub' });
 
-    const groups = await getSubjectGroups(tx, req.currentContext.tokenPayload.sub);
+    const groups = await getSubjectGroups(tx, res.locals.currentContext.tokenPayload.sub);
     const permissions = await Promise.all(groups.map((x) => getGroupPermissions(tx, x.groupId))).then((x) => x.flat());
 
     // Double check correct COMS permissions.
     // This endpoint is called on client bootstrap, so it's a good place to verify
     //   COMS permissions without adding COMS calls to every API request.
-    await assignPermissions(tx, req.currentContext, req.currentContext.tokenPayload.sub);
+    await assignPermissions(tx, res.locals.currentContext, res.locals.currentContext.tokenPayload.sub);
 
     return { groups, permissions };
   });
@@ -80,7 +80,7 @@ export const deleteSubjectGroupController = async (
 
     // Assign new COMS permissions
     try {
-      await assignPermissions(tx, req.currentContext, req.body.sub);
+      await assignPermissions(tx, res.locals.currentContext, req.body.sub);
     } catch (e) {
       if (e instanceof Error) log.warn(e.message);
       if (e instanceof Problem) log.warn(e.detail);

--- a/app/src/interfaces/IExpress.ts
+++ b/app/src/interfaces/IExpress.ts
@@ -1,8 +1,0 @@
-import type { CurrentAuthorization, CurrentContext } from '../types/index.ts';
-
-declare module 'express-serve-static-core' {
-  export interface Request {
-    currentAuthorization: CurrentAuthorization;
-    currentContext: CurrentContext;
-  }
-}

--- a/app/src/middleware/authentication.ts
+++ b/app/src/middleware/authentication.ts
@@ -22,8 +22,8 @@ export const jwtPayloadCache = new LRUCache<string, jwt.JwtPayload>({
 });
 
 /**
- * Authenticates incoming request and injects the current context into request.
- * Subsequent logic should check `req.currentContext.authType` for authentication method if needed.
+ * Authenticates incoming request and injects the current context into response locals.
+ * Subsequent logic should check `res.locals.currentContext.authType` for authentication method if needed.
  * @param initiative The initiative associated with the request.
  * @returns A middleware function.
  * @throws {Problem} The error encountered upon failure.
@@ -34,7 +34,7 @@ export const hasAuthentication = (initiative: Initiative) => {
       const authHeader = getAuthHeader(req, res);
 
       if (authHeader === undefined) {
-        req.currentContext = Object.freeze({
+        res.locals.currentContext = Object.freeze({
           authType: AuthType.NONE,
           initiative
         });
@@ -47,7 +47,7 @@ export const hasAuthentication = (initiative: Initiative) => {
 
         if (!user?.userId) throw new Problem(500, { detail: 'Failed to log user in', instance: req.originalUrl });
 
-        req.currentContext = Object.freeze({
+        res.locals.currentContext = Object.freeze({
           authType: AuthType.BEARER,
           initiative,
           bearerToken: token,

--- a/app/src/middleware/authorization.ts
+++ b/app/src/middleware/authorization.ts
@@ -44,14 +44,14 @@ export const hasAuthorization = (resource: string, action: string) => {
           groups: []
         };
 
-        if (req.currentContext) {
-          const userId = await getCurrentUserId(tx, getCurrentSubject(req.currentContext), SYSTEM_ID);
+        if (res.locals.currentContext) {
+          const userId = await getCurrentUserId(tx, getCurrentSubject(res.locals.currentContext), SYSTEM_ID);
 
           if (!userId) {
             throw new Error('Invalid user');
           }
 
-          const sub = req.currentContext?.tokenPayload?.sub;
+          const sub = res.locals.currentContext?.tokenPayload?.sub;
 
           if (!sub) {
             throw new Error('No subject');
@@ -67,7 +67,7 @@ export const hasAuthorization = (resource: string, action: string) => {
           if (!groups.find((x) => x.name === GroupName.DEVELOPER)) {
             let policyDetails;
 
-            if (req.currentContext.initiative === Initiative.PCNS) {
+            if (res.locals.currentContext.initiative === Initiative.PCNS) {
               const groupNames = Array.from(new Set(groups.map((x) => x.name)));
               policyDetails = await Promise.all(
                 groupNames.map((x) => {
@@ -77,7 +77,7 @@ export const hasAuthorization = (resource: string, action: string) => {
             } else {
               policyDetails = await Promise.all(
                 groups.map((x) => {
-                  return getGroupPolicyDetails(tx, x.groupId, resource, action, req.currentContext?.initiative);
+                  return getGroupPolicyDetails(tx, x.groupId, resource, action, res.locals.currentContext?.initiative);
                 })
               ).then((x) => x.flat());
             }
@@ -111,7 +111,7 @@ export const hasAuthorization = (resource: string, action: string) => {
 
           // Update current authorization and freeze
           currentAuthorization.groups = groups;
-          req.currentAuthorization = Object.freeze(currentAuthorization);
+          res.locals.currentAuthorization = Object.freeze(currentAuthorization);
         } else {
           throw new Error('No current user');
         }
@@ -155,7 +155,7 @@ export const hasAccess = (param: string) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       await transactionWrapper<void>(async (tx: PrismaTransactionClient) => {
-        if (req.currentAuthorization?.attributes.includes('scope:self')) {
+        if (res.locals.currentAuthorization?.attributes.includes('scope:self')) {
           const id = req.params[param];
           if (Array.isArray(id)) {
             throw new TypeError('Parameter must be a string, not an array');
@@ -169,7 +169,7 @@ export const hasAccess = (param: string) => {
 
           // @ts-expect-error Data could be one of may different types. Can this be destructured somehow?
           const activityId: string = data?.activityId ?? id;
-          const contact = await searchContacts(tx, { userId: [req.currentContext.userId!] });
+          const contact = await searchContacts(tx, { userId: [res.locals.currentContext.userId!] });
           const activityContacts = await listActivityContacts(tx, activityId);
 
           if (!activityContacts?.some((ac) => ac.contactId === contact[0].contactId)) {

--- a/app/src/middleware/identity.ts
+++ b/app/src/middleware/identity.ts
@@ -10,7 +10,7 @@ import type { NextFunction, Request, Response } from 'express';
  */
 export const hasIdentity = (identityKind: IdentityProviderKind) => {
   return async (req: Request, res: Response, next: NextFunction) => {
-    if (!hasIdentityUtil(identityKind, req.currentContext)) {
+    if (!hasIdentityUtil(identityKind, res.locals.currentContext)) {
       throw new Problem(403, { detail: 'Invalid user identity' });
     }
     return next();

--- a/app/src/middleware/requireActivityAdmin.ts
+++ b/app/src/middleware/requireActivityAdmin.ts
@@ -25,24 +25,24 @@ export const requireActivityAdmin = async (
 ) => {
   try {
     // Skip if user has scope:all
-    if (req.currentAuthorization.attributes.includes('scope:all')) return next();
+    if (res.locals.currentAuthorization.attributes.includes('scope:all')) return next();
 
     await transactionWrapper<void>(async (tx: PrismaTransactionClient) => {
       let isActivityAdmin = false;
       let isGroupAdmin = false;
 
       // Navigator group check
-      if (req.currentContext.tokenPayload?.sub)
+      if (res.locals.currentContext.tokenPayload?.sub)
         isGroupAdmin = await subjectHasInitiativeGroupName(
           tx,
-          req.currentContext.tokenPayload?.sub,
-          req.currentContext.initiative,
+          res.locals.currentContext.tokenPayload?.sub,
+          res.locals.currentContext.initiative,
           [GroupName.SUPERVISOR, GroupName.NAVIGATOR]
         );
 
       if (!isGroupAdmin) {
         // Proponent team member role check
-        const contact = await searchContacts(tx, { userId: [req.currentContext.userId as string] });
+        const contact = await searchContacts(tx, { userId: [res.locals.currentContext.userId as string] });
         const activityContacts = await listActivityContacts(tx, req.params.activityId);
         const activityContact = activityContacts.find((ac) => ac.contactId === contact[0].contactId);
 

--- a/app/src/middleware/requireSomeAuth.ts
+++ b/app/src/middleware/requireSomeAuth.ts
@@ -14,7 +14,7 @@ import type { NextFunction, Request, Response } from 'express';
  * @returns Express middleware next function.
  */
 export const requireSomeAuth = (req: Request, res: Response, next: NextFunction) => {
-  const authType: string | undefined = req.currentContext ? req.currentContext.authType : undefined;
+  const authType: string | undefined = res.locals.currentContext ? res.locals.currentContext.authType : undefined;
 
   if (!authType || authType === AuthType.NONE) {
     const audience: string = config.get('server.oidc.audience');

--- a/app/src/middleware/requireSomeGroup.ts
+++ b/app/src/middleware/requireSomeGroup.ts
@@ -11,15 +11,15 @@ import type { PrismaTransactionClient } from '../db/database.ts';
  * Attempt to assign proponent groups to users with external IDPs
  * Rejects the request if user has no assigned group
  * @param req Express request object
- * @param _res Express response object
+ * @param res Express response object
  * @param next The next callback function
  * @returns Express middleware function
  * @throws {Problem} The error encountered upon failure
  */
-export const requireSomeGroup = async (req: Request, _res: Response, next: NextFunction) => {
+export const requireSomeGroup = async (req: Request, res: Response, next: NextFunction) => {
   await transactionWrapper<void>(async (tx: PrismaTransactionClient) => {
-    const idp = req.currentContext?.tokenPayload?.identity_provider;
-    const sub = req.currentContext?.tokenPayload?.sub;
+    const idp = res.locals.currentContext?.tokenPayload?.identity_provider;
+    const sub = res.locals.currentContext?.tokenPayload?.sub;
 
     if (!sub) {
       throw new Problem(403, {
@@ -47,7 +47,7 @@ export const requireSomeGroup = async (req: Request, _res: Response, next: NextF
         groups = await getSubjectGroups(tx, sub);
 
         // Assign COMS permissions
-        await assignPermissions(tx, req.currentContext, sub);
+        await assignPermissions(tx, res.locals.currentContext, sub);
       }
     }
 

--- a/app/src/middleware/responseFiltering.ts
+++ b/app/src/middleware/responseFiltering.ts
@@ -20,7 +20,7 @@ export const filterActivityResponseByScope = async (req: Request, res: Response,
     // Store the original res.json function
     const originalJson = res.json;
 
-    const contact = await searchContacts(prisma, { userId: [req.currentContext.userId as string] });
+    const contact = await searchContacts(prisma, { userId: [res.locals.currentContext.userId as string] });
 
     // Override res.json to intercept the response data
     type unknownType = unknown & { activity?: Activity };
@@ -28,7 +28,7 @@ export const filterActivityResponseByScope = async (req: Request, res: Response,
       let filtered = data;
 
       // Check scope and filter as necessary
-      if (req.currentAuthorization?.attributes.includes('scope:self')) {
+      if (res.locals.currentAuthorization?.attributes.includes('scope:self')) {
         if (Array.isArray(data)) {
           filtered = data.filter((x: unknown & { activity?: Activity }) =>
             x.activity?.activityContact?.some((ac) => ac.contactId === contact[0].contactId)

--- a/app/src/routes/v1/map.ts
+++ b/app/src/routes/v1/map.ts
@@ -21,7 +21,7 @@ const INITIATIVE_RESOURCE_MAP = new Map<Initiative, Resource>([
 router.get(
   '/pids/:projectId',
   async (req: Request, res: Response, next: NextFunction) => {
-    const resource = INITIATIVE_RESOURCE_MAP.get(req.currentContext.initiative);
+    const resource = INITIATIVE_RESOURCE_MAP.get(res.locals.currentContext.initiative);
     if (!resource) {
       throw new Error('No resource');
     }

--- a/app/src/types/stuff.d.ts
+++ b/app/src/types/stuff.d.ts
@@ -89,6 +89,11 @@ export interface ContactSearchParameters {
   includeActivities?: boolean;
 }
 
+export interface LocalContext {
+  currentAuthorization: CurrentAuthorization;
+  currentContext: CurrentContext;
+}
+
 export interface CurrentAuthorization {
   attributes: string[];
   groups: Group[];

--- a/app/tests/unit/controllers/accessRequest.spec.ts
+++ b/app/tests/unit/controllers/accessRequest.spec.ts
@@ -73,17 +73,16 @@ const mockSubjectHasGroupName = subjectHasGroupName as Mock;
 const mockRemoveGroup = removeGroup as Mock;
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
   res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 
-let res: { status?: Mock; json?: Mock; end?: Mock };
-beforeEach(() => {
-  res = mockResponse();
-});
+let res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock };
 
 afterEach(() => {
   /*
@@ -95,6 +94,15 @@ afterEach(() => {
 });
 
 describe('createUserAccessRequestController', () => {
+  beforeEach(() => {
+    res = mockResponse();
+
+    res.locals.currentContext = TEST_CURRENT_CONTEXT;
+    res.locals.currentAuthorization = {
+      groups: [{ name: GroupName.ADMIN, initiativeId: 'i1' }]
+    };
+  });
+
   it('automatically updates user group', async () => {
     const req = {
       body: {
@@ -147,6 +155,15 @@ describe('createUserAccessRequestController', () => {
   });
 
   describe('admin', () => {
+    beforeEach(() => {
+      res = mockResponse();
+
+      res.locals.currentContext = TEST_CURRENT_CONTEXT;
+      res.locals.currentAuthorization = {
+        groups: [{ name: GroupName.ADMIN, initiativeId: 'i1' }]
+      };
+    });
+
     it('automatically grants access', async () => {
       const req = {
         body: {
@@ -158,13 +175,6 @@ describe('createUserAccessRequestController', () => {
           user: {
             userId: 'u1'
           }
-        },
-        currentContext: TEST_CURRENT_CONTEXT,
-        currentAuthorization: {
-          groups: [
-            // Makes isUserAdmin return true
-            { name: GroupName.ADMIN, initiativeId: 'i1' }
-          ]
         }
       };
 
@@ -210,10 +220,6 @@ describe('createUserAccessRequestController', () => {
           user: {
             userId: 'u1'
           }
-        },
-        currentContext: TEST_CURRENT_CONTEXT,
-        currentAuthorization: {
-          groups: [{ name: GroupName.ADMIN, initiativeId: 'i1' }]
         }
       };
 
@@ -244,6 +250,15 @@ describe('createUserAccessRequestController', () => {
   });
 
   describe('supervisor', () => {
+    beforeEach(() => {
+      res = mockResponse();
+
+      res.locals.currentContext = TEST_CURRENT_CONTEXT;
+      res.locals.currentAuthorization = {
+        groups: [{ name: GroupName.SUPERVISOR, initiativeId: 'i1' }]
+      };
+    });
+
     it('creates access request', async () => {
       const req = {
         body: {
@@ -256,10 +271,6 @@ describe('createUserAccessRequestController', () => {
             sub: 'sub-123',
             idp: IdentityProviderKind.AZUREIDIR
           }
-        },
-        currentContext: TEST_CURRENT_CONTEXT,
-        currentAuthorization: {
-          groups: [{ name: GroupName.SUPERVISOR, initiativeId: 'i1' }]
         }
       };
 
@@ -303,6 +314,12 @@ describe('createUserAccessRequestController', () => {
 });
 
 describe('processUserAccessRequestController', () => {
+  beforeEach(() => {
+    res = mockResponse();
+
+    res.locals.currentContext = TEST_CURRENT_CONTEXT;
+  });
+
   it('approves and grants access', async () => {
     const req = {
       params: { accessRequestId: 'ar-1' },
@@ -348,8 +365,7 @@ describe('processUserAccessRequestController', () => {
   it('approves and removes access', async () => {
     const req = {
       params: { accessRequestId: 'ar-1' },
-      body: { approve: true },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { approve: true }
     };
 
     mockGetAccessRequest.mockResolvedValue({
@@ -390,8 +406,7 @@ describe('processUserAccessRequestController', () => {
   it('rejects access request', async () => {
     const req = {
       params: { accessRequestId: 'ar-1' },
-      body: { approve: false },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { approve: false }
     };
 
     mockGetAccessRequest.mockResolvedValue({
@@ -425,10 +440,14 @@ describe('processUserAccessRequestController', () => {
 });
 
 describe('getAccessRequestsController', () => {
+  beforeEach(() => {
+    res = mockResponse();
+
+    res.locals.currentContext = TEST_CURRENT_CONTEXT;
+  });
+
   it('returns access requests with 200', async () => {
-    const req = {
-      currentContext: TEST_CURRENT_CONTEXT
-    };
+    const req = {};
 
     const mockData = [{ accessRequestId: 'ar-1' }, { accessRequestId: 'ar-2' }];
 

--- a/app/tests/unit/controllers/activityContact.spec.ts
+++ b/app/tests/unit/controllers/activityContact.spec.ts
@@ -51,8 +51,12 @@ let app: express.Express;
 beforeEach(() => {
   app = express();
   app.use(express.json());
-  app.request.currentAuthorization = { attributes: [], groups: [] };
-  app.request.currentContext = TEST_CURRENT_CONTEXT;
+  app.use((_req, res, next) => {
+    res.locals.currentAuthorization = { attributes: [], groups: [] };
+    res.locals.currentContext = TEST_CURRENT_CONTEXT;
+    next();
+  });
+
   app.get('/activity/:activityId/contact', listActivityContactController);
   app.delete('/activity/:activityId/contact/:contactId', deleteActivityContactController);
   app.post('/activity/:activityId/contact/:contactId', createActivityContactController);

--- a/app/tests/unit/controllers/ats.spec.ts
+++ b/app/tests/unit/controllers/ats.spec.ts
@@ -13,16 +13,19 @@ import type { ATSClientResource, ATSEnquiryResource, ATSUserSearchParameters } f
 vi.mock('config');
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
-
+  res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 
 let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -48,8 +51,7 @@ describe('createATSClientController', () => {
         surName: 'Bates',
         regionName: 'HOUSING',
         optOutOfBCStatSurveyInd: 'NO'
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     const created = {
@@ -104,8 +106,7 @@ describe('createATSEnquiryController', () => {
         notes: 'dsdsa',
         enquiryTypeCodes: ['Project Intake'],
         createdBy: 'IDIR\\DONNY'
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     const created = {
@@ -146,8 +147,7 @@ describe('searchATSUsersController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      query: { firstName: 'John' },
-      currentContext: TEST_CURRENT_CONTEXT
+      query: { firstName: 'John' }
     };
 
     const atsUsers = {

--- a/app/tests/unit/controllers/contact.spec.ts
+++ b/app/tests/unit/controllers/contact.spec.ts
@@ -11,12 +11,14 @@ import { uuidv4Pattern } from '../../../src/utils/regexp.ts';
 
 import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
-import type { Contact, ContactSearchParameters } from '../../../src/types/index.ts';
+import type { Contact, ContactSearchParameters, LocalContext } from '../../../src/types/index.ts';
 
 vi.mock('config');
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
   res.end = vi.fn().mockReturnValue(res);
@@ -26,6 +28,7 @@ const mockResponse = () => {
 let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -37,8 +40,7 @@ describe('deleteContactController', () => {
 
   it('should call services and respond with 204', async () => {
     const req = {
-      params: { contactId: '59b6bad3-ed3c-43f6-81f9-bbd1609d880f' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { contactId: '59b6bad3-ed3c-43f6-81f9-bbd1609d880f' }
     } as unknown as Request;
 
     deleteContactSpy.mockResolvedValue();
@@ -58,8 +60,7 @@ describe('getContactController', () => {
   it('should call services and respond with 200 and result', async () => {
     const req = {
       params: { contactId: '59b6bad3-ed3c-43f6-81f9-bbd1609d880f' },
-      query: { includeActivities: false },
-      currentContext: TEST_CURRENT_CONTEXT
+      query: { includeActivities: false }
     } as unknown as Request;
 
     getContactSpy.mockResolvedValue(TEST_CONTACT_1);
@@ -78,8 +79,7 @@ describe('getContactController', () => {
   it('should call services and respond with 200 and result with activity contact if found', async () => {
     const req = {
       params: { contactId: '59b6bad3-ed3c-43f6-81f9-bbd1609d880f' },
-      query: { includeActivities: true },
-      currentContext: TEST_CURRENT_CONTEXT
+      query: { includeActivities: true }
     } as unknown as Request;
 
     getContactSpy.mockResolvedValue(TEST_CONTACT_WITH_ACTIVITY_1);
@@ -101,8 +101,7 @@ describe('searchContactsController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      body: { userId: '5e3f0c19-8664-4a43-ac9e-210da336e923' },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { userId: '5e3f0c19-8664-4a43-ac9e-210da336e923' }
     } as unknown as Request;
 
     const contacts = [TEST_CONTACT_1];
@@ -130,8 +129,7 @@ describe('searchContactsController', () => {
 
   it('adds dashes to user IDs', async () => {
     const req = {
-      body: { userId: '5e3f0c1986644a43ac9e210da336e923,8b9dedd279d442c6b82f52844a8e2757' },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { userId: '5e3f0c1986644a43ac9e210da336e923,8b9dedd279d442c6b82f52844a8e2757' }
     } as unknown as Request;
 
     const contacts = [TEST_CONTACT_1];
@@ -157,8 +155,7 @@ describe('searchContactsController', () => {
 
   it('adds dashes to contact IDs', async () => {
     const req = {
-      body: { contactId: '5e3f0c1986644a43ac9e210da336e923,8b9dedd279d442c6b82f52844a8e2757' },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { contactId: '5e3f0c1986644a43ac9e210da336e923,8b9dedd279d442c6b82f52844a8e2757' }
     } as unknown as Request;
 
     const contacts = [TEST_CONTACT_1];
@@ -194,15 +191,14 @@ describe('updateContactController', () => {
           email: 'first.last@gov.bc.ca',
           firstName: 'First',
           lastName: 'Last'
-        },
-        currentContext: TEST_CURRENT_CONTEXT
+        }
       } as unknown as Request;
 
       upsertContactsSpy.mockResolvedValueOnce([TEST_CONTACT_1]);
 
       await upsertContactController(
         req as unknown as Request<never, never, Contact, never>,
-        res as unknown as Response
+        res as unknown as Response<Contact, LocalContext>
       );
 
       expect(upsertContactsSpy).toHaveBeenCalledTimes(1);
@@ -227,15 +223,14 @@ describe('updateContactController', () => {
           email: 'first.last@gov.bc.ca',
           firstName: 'First',
           lastName: 'Last'
-        },
-        currentContext: TEST_CURRENT_CONTEXT
+        }
       } as unknown as Request;
 
       upsertContactsSpy.mockResolvedValueOnce([TEST_CONTACT_1]);
 
       await upsertContactController(
         req as unknown as Request<never, never, Contact, never>,
-        res as unknown as Response
+        res as unknown as Response<Contact, LocalContext>
       );
 
       expect(upsertContactsSpy).toHaveBeenCalledTimes(1);

--- a/app/tests/unit/controllers/document.spec.ts
+++ b/app/tests/unit/controllers/document.spec.ts
@@ -14,7 +14,9 @@ import type { Mock } from 'vitest';
 vi.mock('config');
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
   res.end = vi.fn().mockReturnValue(res);
@@ -24,6 +26,7 @@ const mockResponse = () => {
 let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -42,8 +45,7 @@ describe('createDocumentController', () => {
         filename: 'testfile',
         mimeType: 'imgjpg',
         filesize: 1234567
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     createSpy.mockResolvedValue(TEST_DOCUMENT_1);
@@ -79,8 +81,7 @@ describe('createDocumentController', () => {
         filename: 'testfile',
         mimeType: 'imgjpg',
         filesize: 1234567
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     const DOC = { ...TEST_DOCUMENT_1, createdBy: TEST_IDIR_USER_1.userId };
@@ -119,8 +120,7 @@ describe('deleteDocumentController', () => {
 
   it('should call services and respond with 204', async () => {
     const req = {
-      params: { documentId: 'fdbe13d4-e90f-4119-9b10-d5ed08ad1d6d' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { documentId: 'fdbe13d4-e90f-4119-9b10-d5ed08ad1d6d' }
     };
 
     deleteSpy.mockResolvedValue();
@@ -140,8 +140,7 @@ describe('listDocumentsController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      params: { activityId: 'ACTI1234' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { activityId: 'ACTI1234' }
     };
 
     listSpy.mockResolvedValue([TEST_DOCUMENT_1]);
@@ -156,8 +155,7 @@ describe('listDocumentsController', () => {
 
   it('adds createdByFullName', async () => {
     const req = {
-      params: { activityId: 'ACTI1234' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { activityId: 'ACTI1234' }
     };
 
     const DOC = { ...TEST_DOCUMENT_1, createdBy: TEST_IDIR_USER_1.userId };

--- a/app/tests/unit/controllers/electrificationProject.spec.ts
+++ b/app/tests/unit/controllers/electrificationProject.spec.ts
@@ -51,16 +51,19 @@ import type {
 vi.mock('config');
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
   res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 
-let res: { status?: Mock; json?: Mock; end?: Mock };
+let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -91,8 +94,7 @@ describe('createElectrificationProjectController', () => {
           projectType: null,
           bcHydroNumber: null
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_ELECTRIFICATION);
@@ -150,8 +152,7 @@ describe('deleteElectrificationProjectController', () => {
 
   it('should call services and respond with 204', async () => {
     const req = {
-      params: { electrificationProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { electrificationProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' }
     };
 
     getElectrificationProjectSpy.mockResolvedValue(TEST_ELECTRIFICATION_PROJECT_1);
@@ -185,8 +186,7 @@ describe('deleteElectrificationProjectDraftController', () => {
 
   it('should call services and respond with 204', async () => {
     const req = {
-      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' }
     };
 
     getDraftSpy.mockResolvedValue(TEST_ELECTRIFICATION_DRAFT);
@@ -210,9 +210,7 @@ describe('getElectrificationProjectActivityIdsController', () => {
   const getElectrificationProjectsSpy = vi.spyOn(electrificationProjectService, 'getElectrificationProjects');
 
   it('should call services and respond with 200 and result', async () => {
-    const req = {
-      currentContext: TEST_CURRENT_CONTEXT
-    };
+    const req = {};
 
     getElectrificationProjectsSpy.mockResolvedValue([TEST_ELECTRIFICATION_PROJECT_1]);
 
@@ -230,8 +228,7 @@ describe('getElectrificationProjectDraftController', () => {
 
   it('should call services and respond with 200', async () => {
     const req = {
-      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' }
     };
 
     getDraftSpy.mockResolvedValue(TEST_ELECTRIFICATION_DRAFT);
@@ -252,9 +249,7 @@ describe('getElectrificationProjectDraftsController', () => {
   const getDraftsSpy = vi.spyOn(draftService, 'getDrafts');
 
   it('should call services and respond with 200', async () => {
-    const req = {
-      currentContext: TEST_CURRENT_CONTEXT
-    };
+    const req = {};
 
     getDraftsSpy.mockResolvedValue([TEST_ELECTRIFICATION_DRAFT]);
 
@@ -277,8 +272,7 @@ describe('getElectrificationProjectStatistics', () => {
         dateTo: '',
         monthYear: '',
         userId: ''
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     const statistics: ElectrificationProjectStatistics[] = [
@@ -323,8 +317,7 @@ describe('getElectrificationProjectController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      params: { electrificationProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { electrificationProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' }
     };
 
     getElectrificationProjectSpy.mockResolvedValue(TEST_ELECTRIFICATION_PROJECT_1);
@@ -347,7 +340,6 @@ describe('getElectrificationProjectsController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      currentContext: TEST_CURRENT_CONTEXT,
       query: {}
     };
 
@@ -367,8 +359,7 @@ describe('searchElectrificationProjectsController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      body: { activityId: ['ACTI1234', 'ACTI5678'], includeUser: false },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { activityId: ['ACTI1234', 'ACTI5678'], includeUser: false }
     };
 
     searchElectrificationProjectsSpy.mockResolvedValue([TEST_ELECTRIFICATION_PROJECT_1]);
@@ -398,8 +389,7 @@ describe('submitElectrificationProjectDraftController', () => {
 
   it('should call services and respond with 201 and result', async () => {
     const req = {
-      body: { ...TEST_ELECTRIFICATION_INTAKE },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { ...TEST_ELECTRIFICATION_INTAKE }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_ELECTRIFICATION);
@@ -452,8 +442,7 @@ describe('submitElectrificationProjectDraftController', () => {
 
   it('should delete associated draft if it exists', async () => {
     const req = {
-      body: { ...TEST_ELECTRIFICATION_INTAKE, draftId: '44dc87a5-a441-4904-8a27-11f8a41c8d87' },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { ...TEST_ELECTRIFICATION_INTAKE, draftId: '44dc87a5-a441-4904-8a27-11f8a41c8d87' }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_ELECTRIFICATION);
@@ -488,8 +477,7 @@ describe('updateElectrificationProjectDraftController', () => {
             lastName: 'person'
           }
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_ELECTRIFICATION);
@@ -540,8 +528,7 @@ describe('updateElectrificationProjectDraftController', () => {
             lastName: 'person'
           }
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     updateDraftSpy.mockResolvedValue(TEST_ELECTRIFICATION_DRAFT);
@@ -582,7 +569,7 @@ describe('updateElectrificationProjectController', () => {
   it('should call services and respond with 200 and result', async () => {
     const req = {
       body: TEST_ELECTRIFICATION_PROJECT_UPDATE,
-      currentContext: TEST_CURRENT_CONTEXT,
+
       params: {
         electrificationProjectId
       }

--- a/app/tests/unit/controllers/enquiry.spec.ts
+++ b/app/tests/unit/controllers/enquiry.spec.ts
@@ -33,16 +33,19 @@ import type { ActivityContact, Enquiry, EnquiryIntake, EnquirySearchParameters }
 vi.mock('config');
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
   res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 
-let res: { status?: Mock; json?: Mock; end?: Mock };
+let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -63,8 +66,7 @@ describe('createEnquiryController', () => {
 
   it('should call services and respond with 201 and result', async () => {
     const req = {
-      body: TEST_ENQUIRY_INTAKE,
-      currentContext: TEST_CURRENT_CONTEXT
+      body: TEST_ENQUIRY_INTAKE
     };
 
     const PROJECT_WITH_PROJECTID = {
@@ -122,8 +124,7 @@ describe('deleteEnquiryController', () => {
 
   it('should call services and respond with 204', async () => {
     const req = {
-      params: { enquiryId: 'ff5db6e3-3bd4-4a5c-b001-aa5ae3d72211' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { enquiryId: 'ff5db6e3-3bd4-4a5c-b001-aa5ae3d72211' }
     };
 
     getEnquirySpy.mockResolvedValue(TEST_ENQUIRY_1);
@@ -152,10 +153,7 @@ describe('getEnquiriesController', () => {
   const getEnquiriesSpy = vi.spyOn(enquiryService, 'getEnquiries');
 
   it('should call services and respond with 200 and result', async () => {
-    const req = {
-      currentContext: TEST_CURRENT_CONTEXT,
-      currentAuthorization: { attributes: [] }
-    } as unknown as Request;
+    const req = {} as unknown as Request;
 
     const enquiries: Enquiry[] = [TEST_ENQUIRY_1];
     getEnquiriesSpy.mockResolvedValue(enquiries);
@@ -173,8 +171,7 @@ describe('getEnquiryController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      params: { enquiryId: 'ff5db6e3-3bd4-4a5c-b001-aa5ae3d72211' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { enquiryId: 'ff5db6e3-3bd4-4a5c-b001-aa5ae3d72211' }
     } as unknown as Request<{ enquiryId: string }>;
 
     getEnquirySpy.mockResolvedValue(TEST_ENQUIRY_1);
@@ -211,9 +208,7 @@ describe('searchEnquiriesController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      body: { enquiryId: ['ff5db6e3-3bd4-4a5c-b001-aa5ae3d72211'], includeUser: true },
-      currentContext: TEST_CURRENT_CONTEXT,
-      currentAuthorization: { attributes: [] }
+      body: { enquiryId: ['ff5db6e3-3bd4-4a5c-b001-aa5ae3d72211'], includeUser: true }
     } as unknown as Request<never, never, EnquirySearchParameters, never>;
 
     const enquiries: Enquiry[] = [TEST_ENQUIRY_1];
@@ -240,7 +235,6 @@ describe('updateEnquiryController', () => {
   it('should call services and respond with 200 and result', async () => {
     const req = {
       body: { ...TEST_ENQUIRY_1 },
-      currentContext: TEST_CURRENT_CONTEXT,
       params: { enquiryId: TEST_ENQUIRY_1.enquiryId }
     };
 

--- a/app/tests/unit/controllers/generalProject.spec.ts
+++ b/app/tests/unit/controllers/generalProject.spec.ts
@@ -59,16 +59,19 @@ import type {
 vi.mock('config');
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
   res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 
-let res: { status?: Mock; json?: Mock; end?: Mock };
+let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -91,8 +94,7 @@ describe('createGeneralProjectController', () => {
 
   it('should call services and respond with 201 and result', async () => {
     const req = {
-      body: { ...TEST_GENERAL_PROJECT_INTAKE },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { ...TEST_GENERAL_PROJECT_INTAKE }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_GENERAL);
@@ -158,8 +160,7 @@ describe('createGeneralProjectController', () => {
           appliedPermits: [permit1NoTracking, permit2NoTracking],
           investigatePermits: [TEST_PERMIT_3]
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_GENERAL);
@@ -241,8 +242,7 @@ describe('deleteGeneralProjectController', () => {
 
   it('should call services and respond with 204', async () => {
     const req = {
-      params: { generalProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { generalProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' }
     };
 
     getGeneralProjectSpy.mockResolvedValue(TEST_GENERAL_PROJECT_1);
@@ -276,8 +276,7 @@ describe('deleteGeneralProjectDraftController', () => {
 
   it('should call services and respond with 204', async () => {
     const req = {
-      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' }
     };
 
     getDraftSpy.mockResolvedValue(TEST_GENERAL_DRAFT);
@@ -301,9 +300,7 @@ describe('getGeneralProjectActivityIdsController', () => {
   const getGeneralProjectsSpy = vi.spyOn(generalProjectService, 'getGeneralProjects');
 
   it('should call services and respond with 200 and result', async () => {
-    const req = {
-      currentContext: TEST_CURRENT_CONTEXT
-    };
+    const req = {};
 
     getGeneralProjectsSpy.mockResolvedValue([TEST_GENERAL_PROJECT_1]);
 
@@ -321,8 +318,7 @@ describe('getGeneralProjectDraftController', () => {
 
   it('should call services and respond with 200', async () => {
     const req = {
-      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' }
     };
 
     getDraftSpy.mockResolvedValue(TEST_GENERAL_DRAFT);
@@ -340,9 +336,7 @@ describe('getGeneralProjectDraftsController', () => {
   const getDraftsSpy = vi.spyOn(draftService, 'getDrafts');
 
   it('should call services and respond with 200', async () => {
-    const req = {
-      currentContext: TEST_CURRENT_CONTEXT
-    };
+    const req = {};
 
     getDraftsSpy.mockResolvedValue([TEST_GENERAL_DRAFT]);
 
@@ -365,8 +359,7 @@ describe('getGeneralProjectStatisticsController', () => {
         dateTo: '',
         monthYear: '',
         userId: ''
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     const statistics: GeneralProjectStatistics[] = [
@@ -411,8 +404,7 @@ describe('getGeneralProjectController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      params: { generalProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { generalProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' }
     };
 
     generalProjectSpy.mockResolvedValue(TEST_GENERAL_PROJECT_1);
@@ -435,7 +427,6 @@ describe('getGeneralProjectsController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      currentContext: TEST_CURRENT_CONTEXT,
       query: {}
     };
 
@@ -455,8 +446,7 @@ describe('searchGeneralProjectsController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      body: { activityId: ['ACTI1234', 'ACTI5678'], includeUser: false },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { activityId: ['ACTI1234', 'ACTI5678'], includeUser: false }
     };
 
     searchGeneralProjectsSpy.mockResolvedValue([TEST_GENERAL_PROJECT_1]);
@@ -488,8 +478,7 @@ describe('submitGeneralProjectDraftController', () => {
 
   it('should call services and respond with 201 and result', async () => {
     const req = {
-      body: { ...TEST_GENERAL_PROJECT_INTAKE },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { ...TEST_GENERAL_PROJECT_INTAKE }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_GENERAL);
@@ -539,8 +528,7 @@ describe('submitGeneralProjectDraftController', () => {
 
   it('should delete associated draft if it exists', async () => {
     const req = {
-      body: { ...TEST_GENERAL_PROJECT_INTAKE, draftId: '44dc87a5-a441-4904-8a27-11f8a41c8d87' },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { ...TEST_GENERAL_PROJECT_INTAKE, draftId: '44dc87a5-a441-4904-8a27-11f8a41c8d87' }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_GENERAL);
@@ -567,8 +555,7 @@ describe('submitGeneralProjectDraftController', () => {
     const req = {
       body: {
         permits: { appliedPermits: [permit1NoTracking, permit2NoTracking], investigatePermits: [TEST_PERMIT_3] }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_GENERAL);
@@ -668,8 +655,7 @@ describe('updateGeneralProjectDraftController', () => {
             hasAppliedProvincialPermits: true
           }
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_GENERAL);
@@ -726,8 +712,7 @@ describe('updateGeneralProjectDraftController', () => {
             hasAppliedProvincialPermits: true
           }
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     updateDraftSpy.mockResolvedValue(TEST_GENERAL_DRAFT);
@@ -765,7 +750,7 @@ describe('updateGeneralProjectController', () => {
   it('should call services and respond with 200 and result', async () => {
     const req = {
       body: TEST_GENERAL_PROJECT_UPDATE,
-      currentContext: TEST_CURRENT_CONTEXT,
+
       params: {
         generalProjectId
       }

--- a/app/tests/unit/controllers/housingProject.spec.ts
+++ b/app/tests/unit/controllers/housingProject.spec.ts
@@ -65,16 +65,19 @@ const PROJECT_WITH_PROJECTID = {
 };
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
   res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 
-let res: { status?: Mock; json?: Mock; end?: Mock };
+let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -232,8 +235,7 @@ describe('createHousingProjectController', () => {
 
   it('should call services and respond with 201 and result', async () => {
     const req = {
-      body: { ...TEST_HOUSING_PROJECT_INTAKE },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { ...TEST_HOUSING_PROJECT_INTAKE }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_HOUSING);
@@ -302,8 +304,7 @@ describe('createHousingProjectController', () => {
           appliedPermits: [permit1NoTracking, permit2NoTracking],
           investigatePermits: [TEST_PERMIT_3]
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_HOUSING);
@@ -385,8 +386,7 @@ describe('deleteHousingProjectController', () => {
 
   it('should call services and respond with 204', async () => {
     const req = {
-      params: { housingProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { housingProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' }
     };
 
     getHousingProjectSpy.mockResolvedValue(PROJECT_WITH_PROJECTID);
@@ -420,8 +420,7 @@ describe('deleteHousingProjectDraftController', () => {
 
   it('should call services and respond with 204', async () => {
     const req = {
-      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' }
     };
 
     getDraftSpy.mockResolvedValue(TEST_HOUSING_DRAFT);
@@ -445,9 +444,7 @@ describe('getHousingProjectActivityIdsController', () => {
   const getHousingProjectsSpy = vi.spyOn(housingProjectService, 'getHousingProjects');
 
   it('should call services and respond with 200 and result', async () => {
-    const req = {
-      currentContext: TEST_CURRENT_CONTEXT
-    };
+    const req = {};
 
     getHousingProjectsSpy.mockResolvedValue([PROJECT_WITH_PROJECTID]);
 
@@ -465,8 +462,7 @@ describe('getHousingProjectDraftController', () => {
 
   it('should call services and respond with 200', async () => {
     const req = {
-      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { draftId: 'ee25619b-4145-4fc6-aa47-c79f1213eaa6' }
     };
 
     getDraftSpy.mockResolvedValue(TEST_HOUSING_DRAFT);
@@ -484,9 +480,7 @@ describe('getHousingProjectDraftsController', () => {
   const getDraftsSpy = vi.spyOn(draftService, 'getDrafts');
 
   it('should call services and respond with 200', async () => {
-    const req = {
-      currentContext: TEST_CURRENT_CONTEXT
-    };
+    const req = {};
 
     getDraftsSpy.mockResolvedValue([TEST_HOUSING_DRAFT]);
 
@@ -509,8 +503,7 @@ describe('getHousingProjectStatisticsController', () => {
         dateTo: '',
         monthYear: '',
         userId: ''
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     const statistics: HousingProjectStatistics[] = [
@@ -559,8 +552,7 @@ describe('getHousingProjectController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      params: { housingProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { housingProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' }
     };
 
     housingProjectSpy.mockResolvedValue(PROJECT_WITH_PROJECTID);
@@ -583,7 +575,6 @@ describe('getHousingProjectsController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      currentContext: TEST_CURRENT_CONTEXT,
       query: {}
     };
 
@@ -603,8 +594,7 @@ describe('searchHousingProjectsController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      body: { activityId: ['ACTI1234', 'ACTI5678'], includeUser: false },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { activityId: ['ACTI1234', 'ACTI5678'], includeUser: false }
     };
 
     searchHousingProjectsSpy.mockResolvedValue([PROJECT_WITH_PROJECTID]);
@@ -636,8 +626,7 @@ describe('submitHousingProjectDraftController', () => {
 
   it('should call services and respond with 201 and result', async () => {
     const req = {
-      body: { ...TEST_HOUSING_PROJECT_INTAKE },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { ...TEST_HOUSING_PROJECT_INTAKE }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_HOUSING);
@@ -693,8 +682,7 @@ describe('submitHousingProjectDraftController', () => {
 
   it('should delete associated draft if it exists', async () => {
     const req = {
-      body: { ...TEST_HOUSING_PROJECT_INTAKE, draftId: '44dc87a5-a441-4904-8a27-11f8a41c8d87' },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { ...TEST_HOUSING_PROJECT_INTAKE, draftId: '44dc87a5-a441-4904-8a27-11f8a41c8d87' }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_HOUSING);
@@ -724,8 +712,7 @@ describe('submitHousingProjectDraftController', () => {
           appliedPermits: [permit1NoTracking, permit2NoTracking],
           investigatePermits: [TEST_PERMIT_3]
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_HOUSING);
@@ -825,8 +812,7 @@ describe('updateHousingProjectDraftController', () => {
             hasAppliedProvincialPermits: true
           }
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     createActivitySpy.mockResolvedValue(TEST_ACTIVITY_HOUSING);
@@ -883,8 +869,7 @@ describe('updateHousingProjectDraftController', () => {
             hasAppliedProvincialPermits: true
           }
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     updateDraftSpy.mockResolvedValue(TEST_HOUSING_DRAFT);
@@ -922,7 +907,6 @@ describe('updateHousingProjectController', () => {
   it('should call services and respond with 200 and result', async () => {
     const req = {
       body: TEST_HOUSING_PROJECT_UPDATE,
-      currentContext: TEST_CURRENT_CONTEXT,
       params: {
         housingProjectId
       }

--- a/app/tests/unit/controllers/map.spec.ts
+++ b/app/tests/unit/controllers/map.spec.ts
@@ -7,9 +7,12 @@ import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
+  res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 

--- a/app/tests/unit/controllers/noteHistory.spec.ts
+++ b/app/tests/unit/controllers/noteHistory.spec.ts
@@ -33,13 +33,16 @@ import type {
   Enquiry,
   GeneralProject,
   HousingProject,
+  LocalContext,
   NoteHistory
 } from '../../../src/types/index.ts';
 
 vi.mock('config');
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
   res.end = vi.fn().mockReturnValue(res);
@@ -49,6 +52,7 @@ const mockResponse = () => {
 let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -56,6 +60,7 @@ afterEach(() => {
 });
 
 const CURRENT_AUTHORIZATION = {
+  groups: [],
   attributes: [] as string[]
 };
 
@@ -67,8 +72,7 @@ describe('createNoteHistoryController', () => {
 
   it('should call services and respond with 201 and result', async () => {
     const req = {
-      body: { ...TEST_NOTE_HISTORY_1, note: 'Some text' },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { ...TEST_NOTE_HISTORY_1, note: 'Some text' }
     };
 
     createHistorySpy.mockResolvedValue(TEST_NOTE_HISTORY_1);
@@ -84,7 +88,7 @@ describe('createNoteHistoryController', () => {
       ...TEST_NOTE_HISTORY_1,
       noteHistoryId: expect.stringMatching(uuidv4Pattern) as string,
       createdAt: expect.any(Date) as Date,
-      createdBy: req.currentContext.userId
+      createdBy: TEST_CURRENT_CONTEXT.userId
     });
     expect(createNoteSpy).toHaveBeenCalledTimes(1);
     expect(createNoteSpy).toHaveBeenCalledWith(prismaTxMock, {
@@ -92,7 +96,7 @@ describe('createNoteHistoryController', () => {
       noteHistoryId: TEST_NOTE_HISTORY_1.noteHistoryId,
       note: req.body.note,
       createdAt: expect.any(Date) as Date,
-      createdBy: req.currentContext.userId,
+      createdBy: TEST_CURRENT_CONTEXT.userId,
       ...generateNullUpdateStamps(),
       ...generateNullDeleteStamps()
     });
@@ -106,8 +110,7 @@ describe('deleteNoteHistoryController', () => {
 
   it('should call services and respond with 204', async () => {
     const req = {
-      params: { noteHistoryId: 'd9bc3e53-2aad-4160-903f-e62e31e0efd1' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { noteHistoryId: 'd9bc3e53-2aad-4160-903f-e62e31e0efd1' }
     };
 
     deleteHistorySpy.mockResolvedValue();
@@ -117,7 +120,7 @@ describe('deleteNoteHistoryController', () => {
     expect(deleteHistorySpy).toHaveBeenCalledTimes(1);
     expect(deleteHistorySpy).toHaveBeenCalledWith(prismaTxMock, req.params.noteHistoryId, {
       deletedAt: expect.any(Date) as Date,
-      deletedBy: req.currentContext.userId
+      deletedBy: TEST_CURRENT_CONTEXT.userId
     });
     expect(res.status).toHaveBeenCalledWith(204);
     expect(res.end).toHaveBeenCalledWith();
@@ -136,8 +139,7 @@ describe('listBringForwardController', () => {
     const req = {
       query: {
         bringForwardState: BringForwardType.UNRESOLVED
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     const NOTE_HISTORY_LIST: NoteHistory[] = [
@@ -195,9 +197,7 @@ describe('listNoteHistoryController', () => {
   const listNoteHistorySpy = vi.spyOn(noteHistoryService, 'listNoteHistory');
 
   const req = {
-    params: { activityId: 'ACTI1234' },
-    currentAuthorization: CURRENT_AUTHORIZATION,
-    currentContext: TEST_CURRENT_CONTEXT
+    params: { activityId: 'ACTI1234' }
   };
 
   it('should call services and respond with 200 and result', async () => {
@@ -214,7 +214,8 @@ describe('listNoteHistoryController', () => {
   });
 
   it('should filter results if scope:self and shownToProponent = true', async () => {
-    req.currentAuthorization.attributes.push('scope:self');
+    (res.locals as unknown as LocalContext).currentAuthorization = CURRENT_AUTHORIZATION;
+    (res.locals as unknown as LocalContext).currentAuthorization.attributes.push('scope:self');
 
     const NOTE_HISTORY_LIST: NoteHistory[] = [TEST_NOTE_HISTORY_1, TEST_NOTE_HISTORY_2];
 
@@ -239,7 +240,7 @@ describe('updateNoteHistoryController', () => {
   it('should call services and respond with 200 and result', async () => {
     const req = {
       body: { ...UPDATED_HISTORY },
-      currentContext: TEST_CURRENT_CONTEXT,
+
       params: {
         noteHistoryId: 'd9bc3e53-2aad-4160-903f-e62e31e0efd1'
       }
@@ -254,14 +255,14 @@ describe('updateNoteHistoryController', () => {
         never,
         NoteHistory & { note: string | undefined; resource: Resource }
       >,
-      res as unknown as Response
+      res as unknown as Response<NoteHistory, LocalContext>
     );
 
     expect(updateNoteHistorySpy).toHaveBeenCalledTimes(1);
     expect(updateNoteHistorySpy).toHaveBeenCalledWith(prismaTxMock, {
       ...UPDATED_HISTORY,
       updatedAt: expect.any(Date) as Date,
-      updatedBy: req.currentContext.userId
+      updatedBy: TEST_CURRENT_CONTEXT.userId
     });
     expect(getNoteHistorySpy).toHaveBeenCalledTimes(1);
     expect(getNoteHistorySpy).toHaveBeenCalledWith(prismaTxMock, req.params.noteHistoryId);
@@ -272,7 +273,6 @@ describe('updateNoteHistoryController', () => {
   it('creates a new note if given', async () => {
     const req = {
       body: { ...UPDATED_HISTORY, note: 'Some text' },
-      currentContext: TEST_CURRENT_CONTEXT,
       params: {
         noteHistoryId: 'd9bc3e53-2aad-4160-903f-e62e31e0efd1'
       }
@@ -287,7 +287,7 @@ describe('updateNoteHistoryController', () => {
         never,
         NoteHistory & { note: string | undefined; resource: Resource }
       >,
-      res as unknown as Response
+      res as unknown as Response<NoteHistory, LocalContext>
     );
 
     expect(createNoteSpy).toHaveBeenCalledTimes(1);
@@ -296,7 +296,7 @@ describe('updateNoteHistoryController', () => {
       noteHistoryId: req.params.noteHistoryId,
       note: req.body.note,
       createdAt: expect.any(Date) as Date,
-      createdBy: req.currentContext.userId,
+      createdBy: TEST_CURRENT_CONTEXT.userId,
       ...generateNullUpdateStamps(),
       ...generateNullDeleteStamps()
     });

--- a/app/tests/unit/controllers/permit.spec.ts
+++ b/app/tests/unit/controllers/permit.spec.ts
@@ -62,7 +62,9 @@ vi.mock('../../../src/utils/templates.ts', async (importOriginal) => {
 });
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
   res.end = vi.fn().mockReturnValue(res);
@@ -70,9 +72,9 @@ const mockResponse = () => {
 };
 
 let res = mockResponse();
-
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -84,8 +86,7 @@ describe('deletePermitController', () => {
 
   it('should call services and respond with 204', async () => {
     const req = {
-      params: { permitId: '1381438d-0c7a-46bf-8ae2-d1febbf27066' },
-      currentContext: TEST_CURRENT_CONTEXT
+      params: { permitId: '1381438d-0c7a-46bf-8ae2-d1febbf27066' }
     };
 
     deleteSpy.mockResolvedValue();
@@ -104,7 +105,6 @@ describe('getPermitController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      currentContext: TEST_CURRENT_CONTEXT,
       params: { permitId: '1381438d-0c7a-46bf-8ae2-d1febbf27066' }
     };
 
@@ -124,8 +124,7 @@ describe('listPermitsController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      query: { activityId: 'ACTI1234' },
-      currentContext: TEST_CURRENT_CONTEXT
+      query: { activityId: 'ACTI1234' }
     };
 
     listSpy.mockResolvedValue(TEST_PERMIT_LIST);
@@ -144,8 +143,7 @@ describe('listPermitsController', () => {
   it('should include notes if requested', async () => {
     const now = new Date();
     const req = {
-      query: { activityId: 'ACTI1234', includeNotes: 'true' },
-      currentContext: TEST_CURRENT_CONTEXT
+      query: { activityId: 'ACTI1234', includeNotes: 'true' }
     };
 
     const permitList = [
@@ -220,11 +218,12 @@ describe('searchPermitsController', () => {
 
   it('should handle empty query parameters', async () => {
     const req = {
-      query: {},
-      currentContext: {
-        ...TEST_CURRENT_CONTEXT,
-        initiative: Initiative.ELECTRIFICATION
-      }
+      query: {}
+    };
+
+    res.locals.currentContext = {
+      ...TEST_CURRENT_CONTEXT,
+      initiative: Initiative.ELECTRIFICATION
     };
 
     const mockResponse = {
@@ -251,11 +250,12 @@ describe('searchPermitsController', () => {
         permitTypeId: '456',
         skip: '10',
         take: '20'
-      },
-      currentContext: {
-        ...TEST_CURRENT_CONTEXT,
-        initiative: Initiative.HOUSING
       }
+    };
+
+    res.locals.currentContext = {
+      ...TEST_CURRENT_CONTEXT,
+      initiative: Initiative.HOUSING
     };
 
     const mockResponse = {
@@ -280,11 +280,12 @@ describe('searchPermitsController', () => {
     const req = {
       query: {
         permitTypeId: '123'
-      },
-      currentContext: {
-        ...TEST_CURRENT_CONTEXT,
-        initiative: Initiative.PCNS
       }
+    };
+
+    res.locals.currentContext = {
+      ...TEST_CURRENT_CONTEXT,
+      initiative: Initiative.PCNS
     };
 
     await expect(
@@ -316,8 +317,7 @@ describe('upsertPermitController', () => {
         stage: PermitStage.PRE_SUBMISSION,
         submittedDate: now,
         decisionDate: now
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     upsertSpy.mockResolvedValue(TEST_PERMIT_1);

--- a/app/tests/unit/controllers/permitType.spec.ts
+++ b/app/tests/unit/controllers/permitType.spec.ts
@@ -8,7 +8,9 @@ import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
   res.end = vi.fn().mockReturnValue(res);
@@ -16,9 +18,9 @@ const mockResponse = () => {
 };
 
 let res = mockResponse();
-
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -30,7 +32,6 @@ describe('getPermitTypesController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      currentContext: TEST_CURRENT_CONTEXT,
       query: { initiative: Initiative.HOUSING }
     };
 

--- a/app/tests/unit/controllers/reporting.spec.ts
+++ b/app/tests/unit/controllers/reporting.spec.ts
@@ -12,16 +12,19 @@ import type { Mock } from 'vitest';
 vi.mock('config');
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
-
+  res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 
-let res: { status?: Mock; json?: Mock; end?: Mock };
+let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -38,8 +41,7 @@ describe('getElectrificationProjectPermitDataController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      query: {},
-      currentContext: TEST_CURRENT_CONTEXT
+      query: {}
     };
 
     const mockData = [
@@ -100,8 +102,7 @@ describe('getHousingProjectPermitDataController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      query: {},
-      currentContext: TEST_CURRENT_CONTEXT
+      query: {}
     };
 
     const mockData = [

--- a/app/tests/unit/controllers/roadmap.spec.ts
+++ b/app/tests/unit/controllers/roadmap.spec.ts
@@ -11,21 +11,24 @@ import { uuidv4Pattern } from '../../../src/utils/regexp.ts';
 import type { InternalAxiosRequestConfig } from 'axios';
 import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
-import type { Email, Note, NoteHistory } from '../../../src/types';
+import type { CurrentContext, Email, Note, NoteHistory } from '../../../src/types';
 
 vi.mock('config');
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
-
+  res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 
 let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -50,8 +53,7 @@ describe('send', () => {
           to: 'hello@gov.bc.ca',
           subject: 'Unit tests'
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     const createdHistory: NoteHistory = {
@@ -92,8 +94,7 @@ describe('send', () => {
           to: 'hello@gov.bc.ca',
           subject: 'Unit tests'
         }
-      },
-      currentContext: TEST_CURRENT_CONTEXT
+      }
     };
 
     const createdHistory: NoteHistory = {
@@ -124,7 +125,7 @@ describe('send', () => {
       ...createdHistory,
       noteHistoryId: expect.stringMatching(uuidv4Pattern) as string,
       createdAt: expect.any(Date) as Date,
-      createdBy: req.currentContext.userId
+      createdBy: TEST_CURRENT_CONTEXT.userId
     });
     expect(createNoteSpy).toHaveBeenCalledTimes(1);
     expect(createNoteSpy).toHaveBeenCalledWith(prismaTxMock, {
@@ -132,7 +133,7 @@ describe('send', () => {
       noteHistoryId: createdNote.noteHistoryId,
       note: createdNote.note,
       createdAt: expect.any(Date) as Date,
-      createdBy: req.currentContext.userId,
+      createdBy: TEST_CURRENT_CONTEXT.userId,
       ...generateNullUpdateStamps(),
       ...generateNullDeleteStamps()
     });
@@ -167,9 +168,10 @@ describe('send', () => {
           ]
         }
       },
-      currentContext: { ...TEST_CURRENT_CONTEXT, bearerToken: 'token' },
       headers: {}
     };
+
+    res.locals.currentContext = { ...TEST_CURRENT_CONTEXT, bearerToken: 'token' };
 
     const getObjectResponse = {
       data: 'foo',
@@ -211,8 +213,16 @@ describe('send', () => {
     );
 
     expect(getObjectSpy).toHaveBeenCalledTimes(2);
-    expect(getObjectSpy).toHaveBeenNthCalledWith(1, req.currentContext.bearerToken, req.body.selectedFileIds[0]);
-    expect(getObjectSpy).toHaveBeenNthCalledWith(2, req.currentContext.bearerToken, req.body.selectedFileIds[1]);
+    expect(getObjectSpy).toHaveBeenNthCalledWith(
+      1,
+      (res.locals.currentContext as unknown as CurrentContext).bearerToken,
+      req.body.selectedFileIds[0]
+    );
+    expect(getObjectSpy).toHaveBeenNthCalledWith(
+      2,
+      (res.locals.currentContext as unknown as CurrentContext).bearerToken,
+      req.body.selectedFileIds[1]
+    );
     expect(emailSpy).toHaveBeenCalledTimes(1);
     expect(emailSpy).toHaveBeenCalledWith(req.body.emailData);
     expect(res.status).toHaveBeenCalledWith(201);
@@ -304,9 +314,10 @@ describe('send', () => {
           ]
         }
       },
-      currentContext: { ...TEST_CURRENT_CONTEXT, bearerToken: 'token' },
       headers: {}
     };
+
+    res.locals.currentContext = { ...TEST_CURRENT_CONTEXT, bearerToken: 'token' };
 
     const getObjectResponse1 = {
       data: 'foo',
@@ -370,8 +381,16 @@ describe('send', () => {
     );
 
     expect(getObjectSpy).toHaveBeenCalledTimes(2);
-    expect(getObjectSpy).toHaveBeenNthCalledWith(1, req.currentContext.bearerToken, req.body.selectedFileIds[0]);
-    expect(getObjectSpy).toHaveBeenNthCalledWith(2, req.currentContext.bearerToken, req.body.selectedFileIds[1]);
+    expect(getObjectSpy).toHaveBeenNthCalledWith(
+      1,
+      (res.locals.currentContext as unknown as CurrentContext).bearerToken,
+      req.body.selectedFileIds[0]
+    );
+    expect(getObjectSpy).toHaveBeenNthCalledWith(
+      2,
+      (res.locals.currentContext as unknown as CurrentContext).bearerToken,
+      req.body.selectedFileIds[1]
+    );
     expect(emailSpy).toHaveBeenCalledTimes(1);
     expect(emailSpy).toHaveBeenCalledWith(req.body.emailData);
     expect(createHistorySpy).toHaveBeenCalledTimes(1);
@@ -379,7 +398,7 @@ describe('send', () => {
       ...createdHistory,
       noteHistoryId: expect.stringMatching(uuidv4Pattern) as string,
       createdAt: expect.any(Date) as Date,
-      createdBy: req.currentContext.userId
+      createdBy: TEST_CURRENT_CONTEXT.userId
     });
     expect(createNoteSpy).toHaveBeenCalledTimes(1);
     expect(createNoteSpy).toHaveBeenCalledWith(prismaTxMock, {
@@ -387,7 +406,7 @@ describe('send', () => {
       noteHistoryId: createdNote.noteHistoryId,
       note: createdNote.note,
       createdAt: expect.any(Date) as Date,
-      createdBy: req.currentContext.userId,
+      createdBy: TEST_CURRENT_CONTEXT.userId,
       ...generateNullUpdateStamps(),
       ...generateNullDeleteStamps()
     });

--- a/app/tests/unit/controllers/sourceSystemKind.spec.ts
+++ b/app/tests/unit/controllers/sourceSystemKind.spec.ts
@@ -6,9 +6,12 @@ import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
+  res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 

--- a/app/tests/unit/controllers/sso.spec.ts
+++ b/app/tests/unit/controllers/sso.spec.ts
@@ -6,9 +6,12 @@ import type { Mock } from 'vitest';
 import type { IdirSearchParameters } from '../../../src/types/index.ts';
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
+  res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 

--- a/app/tests/unit/controllers/user.spec.ts
+++ b/app/tests/unit/controllers/user.spec.ts
@@ -13,16 +13,19 @@ import type { Group, User, UserSearchParameters } from '../../../src/types/index
 vi.mock('config');
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
-
+  res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 
 let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
 
 afterEach(() => {
@@ -36,8 +39,7 @@ describe('searchUsersController', () => {
 
   it('should call services and respond with 200 and result', async () => {
     const req = {
-      body: { userId: ['5e3f0c19-8664-4a43-ac9e-210da336e923'] },
-      currentContext: TEST_CURRENT_CONTEXT
+      body: { userId: ['5e3f0c19-8664-4a43-ac9e-210da336e923'] }
     };
 
     searchUsersSpy.mockResolvedValue(TEST_USER_LIST);

--- a/app/tests/unit/controllers/yars.spec.ts
+++ b/app/tests/unit/controllers/yars.spec.ts
@@ -14,20 +14,23 @@ import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
 
 const mockResponse = () => {
-  const res: { status?: Mock; json?: Mock; end?: Mock } = {};
+  const res: { locals: Record<string, unknown>; status?: Mock; json?: Mock; end?: Mock } = {
+    locals: {}
+  };
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
   res.end = vi.fn().mockReturnValue(res);
   return res;
 };
 
-const SUB = 'cd90c6bf44074872a7116f4dd4f3a45b@azureidir';
-const ctxWithSub = { ...TEST_CURRENT_CONTEXT, tokenPayload: { sub: SUB } };
-
 let res = mockResponse();
 beforeEach(() => {
   res = mockResponse();
+  res.locals.currentContext = TEST_CURRENT_CONTEXT;
 });
+
+const SUB = 'cd90c6bf44074872a7116f4dd4f3a45b@azureidir';
+const ctxWithSub = { ...TEST_CURRENT_CONTEXT, tokenPayload: { sub: SUB } };
 
 afterEach(() => {
   vi.resetAllMocks();
@@ -88,6 +91,8 @@ describe('listSubjectPermissionsController', () => {
   const assignPermissionsSpy = vi.spyOn(comsService, 'assignPermissions');
 
   it('returns groups and flattened permissions', async () => {
+    res.locals.currentContext = ctxWithSub;
+
     const groups = [{ groupId: 1 }, { groupId: 2 }] as never;
     getSubjectGroupsSpy.mockResolvedValueOnce(groups);
     getGroupPermissionsSpy
@@ -130,6 +135,8 @@ describe('deleteSubjectGroupController', () => {
   const body = { sub: SUB, groupId: 7 };
 
   it('removes group + corresponding global group when no other initiative has the same group name', async () => {
+    res.locals.currentContext = ctxWithSub;
+
     getSubjectGroupsSpy.mockResolvedValueOnce([
       { groupId: 7, name: 'NAVIGATOR', initiativeCode: Initiative.HOUSING }
     ] as never);
@@ -140,7 +147,7 @@ describe('deleteSubjectGroupController', () => {
     assignPermissionsSpy.mockResolvedValueOnce(undefined);
 
     await deleteSubjectGroupController(
-      { body, currentContext: ctxWithSub } as unknown as Request<never, never, typeof body>,
+      { body } as unknown as Request<never, never, typeof body>,
       res as unknown as Response
     );
 

--- a/app/tests/unit/middleware/authentication.test.ts
+++ b/app/tests/unit/middleware/authentication.test.ts
@@ -74,7 +74,9 @@ describe('authentication middleware', () => {
 
     beforeEach(() => {
       req = { originalUrl: '/test' };
-      res = {};
+      res = {
+        locals: {}
+      };
       next = vi.fn();
     });
 
@@ -84,7 +86,7 @@ describe('authentication middleware', () => {
       const middleware = hasAuthentication(INITIATIVE);
       await middleware(req as Request, res as Response, next);
 
-      expect(req.currentContext).toEqual({
+      expect(res.locals?.currentContext).toEqual({
         authType: AuthType.NONE,
         initiative: INITIATIVE
       });
@@ -105,7 +107,7 @@ describe('authentication middleware', () => {
       const middleware = hasAuthentication(INITIATIVE);
       await middleware(req as Request, res as Response, next);
 
-      expect(req.currentContext).toEqual({
+      expect(res.locals?.currentContext).toEqual({
         authType: AuthType.BEARER,
         initiative: INITIATIVE,
         bearerToken: token,

--- a/app/tests/unit/middleware/authorization.test.ts
+++ b/app/tests/unit/middleware/authorization.test.ts
@@ -18,14 +18,14 @@ const CONTACT_ID = 'contact-1';
 
 function buildAppForHasAuthorization(currentContext: unknown) {
   const app = express();
-  app.use((req, _res, next) => {
-    (req as Request).currentContext = currentContext as Request['currentContext'];
+  app.use((_req, res, next) => {
+    res.locals.currentContext = currentContext;
     next();
   });
   app.get('/test', hasAuthorization('document', 'read'), (req: Request, res: Response) => {
     res.status(200).json({
-      attributes: req.currentAuthorization?.attributes,
-      groupCount: req.currentAuthorization?.groups.length
+      attributes: res.locals.currentAuthorization?.attributes,
+      groupCount: res.locals.currentAuthorization?.groups.length
     });
   });
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -37,9 +37,9 @@ function buildAppForHasAuthorization(currentContext: unknown) {
 
 function buildAppForHasAccess(currentAuthorization: unknown, currentContext: unknown, route = '/d/:documentId') {
   const app = express();
-  app.use((req, _res, next) => {
-    (req as Request).currentContext = currentContext as Request['currentContext'];
-    (req as Request).currentAuthorization = currentAuthorization as Request['currentAuthorization'];
+  app.use((_req, res, next) => {
+    res.locals.currentContext = currentContext;
+    res.locals.currentAuthorization = currentAuthorization;
     next();
   });
   app.get(route, hasAccess(route.includes(':documentId') ? 'documentId' : 'activityId'), (_req, res) => {

--- a/app/tests/unit/middleware/identity.test.ts
+++ b/app/tests/unit/middleware/identity.test.ts
@@ -38,7 +38,7 @@ function buildApp(kind: IdentityProviderKind, contextPayloadOverride?: CurrentCo
   app.use(express.json());
 
   app.use((req: Request, res: Response, next: NextFunction) => {
-    req.currentContext = {
+    res.locals.currentContext = {
       ...TEST_CURRENT_CONTEXT,
       ...contextPayloadOverride
     };

--- a/app/tests/unit/middleware/requireActivityAdmin.test.ts
+++ b/app/tests/unit/middleware/requireActivityAdmin.test.ts
@@ -10,8 +10,14 @@ import { ActivityContactRole } from '../../../src/utils/enums/projectCommon.ts';
 import type { NextFunction, Request, Response } from 'express';
 import type Problem from '../../../src/utils/problem.ts';
 
-function buildApp() {
+function buildApp(locals?: Record<string, unknown>) {
   const app = express();
+
+  app.use((req, res, next) => {
+    Object.assign(res.locals, locals);
+    next();
+  });
+
   // Body parsers
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
@@ -33,20 +39,25 @@ function buildApp() {
   return app;
 }
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('requireActivityAdmin middleware', () => {
   let app: express.Express;
 
   const searchContactsSpy = vi.spyOn(contactService, 'searchContacts');
   const listActivityContactsSpy = vi.spyOn(activityContactService, 'listActivityContacts');
 
-  beforeEach(() => {
-    app = buildApp();
-    app.request.currentContext = TEST_CURRENT_CONTEXT;
-  });
-
   describe('scope:all', () => {
     beforeEach(() => {
-      app.request.currentAuthorization = { attributes: ['scope:all'], groups: [] };
+      app = buildApp({
+        currentContext: TEST_CURRENT_CONTEXT,
+        currentAuthorization: {
+          attributes: ['scope:all'],
+          groups: []
+        }
+      });
     });
 
     it('immediately calls next', async () => {
@@ -67,7 +78,13 @@ describe('requireActivityAdmin middleware', () => {
 
   describe('scope:self', () => {
     beforeEach(() => {
-      app.request.currentAuthorization = { attributes: ['scope:self'], groups: [] };
+      app = buildApp({
+        currentContext: TEST_CURRENT_CONTEXT,
+        currentAuthorization: {
+          attributes: ['scope:self'],
+          groups: []
+        }
+      });
     });
 
     it('allows PRIMARY through', async () => {

--- a/app/tests/unit/middleware/requireSomeAuth.test.ts
+++ b/app/tests/unit/middleware/requireSomeAuth.test.ts
@@ -14,8 +14,8 @@ const mockedConfig = config as Mocked<typeof config>;
 
 function buildApp(currentContext: unknown) {
   const app = express();
-  app.use((req, _res, next) => {
-    (req as Request).currentContext = currentContext as Request['currentContext'];
+  app.use((_req, res, next) => {
+    res.locals.currentContext = currentContext;
     next();
   });
   app.use(requireSomeAuth);

--- a/app/tests/unit/middleware/requireSomeGroup.test.ts
+++ b/app/tests/unit/middleware/requireSomeGroup.test.ts
@@ -11,8 +11,8 @@ import type Problem from '../../../src/utils/problem.ts';
 
 function buildApp(currentContext: unknown) {
   const app = express();
-  app.use((req, _res, next) => {
-    (req as Request).currentContext = currentContext as Request['currentContext'];
+  app.use((_req, res, next) => {
+    res.locals.currentContext = currentContext;
     next();
   });
   app.get('/ok', requireSomeGroup, (_req, res) => res.status(200).json({ ok: true }));

--- a/app/tests/unit/middleware/responseFiltering.test.ts
+++ b/app/tests/unit/middleware/responseFiltering.test.ts
@@ -7,11 +7,16 @@ import * as contactService from '../../../src/services/contact.ts';
 
 import type { Request, Response } from 'express';
 
-function buildApp() {
+function buildApp(currentAuthorization = { attributes: [] as string[], groups: [] }) {
   const app = express();
   // Body parsers
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
+  app.use((_req, res, next) => {
+    res.locals.currentAuthorization = currentAuthorization;
+    res.locals.currentContext = TEST_CURRENT_CONTEXT;
+    next();
+  });
   app.use(filterActivityResponseByScope);
 
   // Endpoints
@@ -58,17 +63,12 @@ describe('filterActivityResponseByScope middleware', () => {
 
   const searchContactsSpy = vi.spyOn(contactService, 'searchContacts');
 
-  beforeEach(() => {
-    app = buildApp();
-    app.request.currentContext = TEST_CURRENT_CONTEXT;
-  });
-
   describe('scope:self attribute present', () => {
     it('filters array response', async () => {
-      app.request.currentAuthorization = {
+      app = buildApp({
         attributes: ['scope:self'],
         groups: []
-      };
+      });
 
       searchContactsSpy.mockResolvedValue([TEST_CONTACT_1]);
 
@@ -89,10 +89,10 @@ describe('filterActivityResponseByScope middleware', () => {
     });
 
     it('filters object response', async () => {
-      app.request.currentAuthorization = {
+      app = buildApp({
         attributes: ['scope:self'],
         groups: []
-      };
+      });
 
       searchContactsSpy.mockResolvedValue([TEST_CONTACT_1]);
 
@@ -105,10 +105,10 @@ describe('filterActivityResponseByScope middleware', () => {
 
   describe('scope:all attribute present', () => {
     it('does not filter response', async () => {
-      app.request.currentAuthorization = {
+      app = buildApp({
         attributes: ['scope:all'],
         groups: []
-      };
+      });
 
       searchContactsSpy.mockResolvedValue([TEST_CONTACT_1]);
 
@@ -139,10 +139,10 @@ describe('filterActivityResponseByScope middleware', () => {
   });
 
   it('returns 403 when an error happens', async () => {
-    app.request.currentAuthorization = {
-      attributes: ['scope:self'],
+    app = buildApp({
+      attributes: ['scope:all'],
       groups: []
-    };
+    });
 
     searchContactsSpy.mockImplementationOnce(() => {
       throw new Error('boom');


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Move `CurrentContext` and `CurrentAuthorization` from the Express Request object to `res.locals`.

This aligns request-scoped context storage with Express conventions and reduces the need for custom Request type augmentation. All middleware and handlers have been updated to read the context from `res.locals`.

No functional behavior changes are expected.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->