### PR TITLE
fix: align peach summary request payload structure

### DIFF
--- a/app/src/controllers/peach.ts
+++ b/app/src/controllers/peach.ts
@@ -67,8 +67,11 @@ export const findPriorityPermitTracking = (
  * @param req Express Request object
  * @param res Express Response object
  */
-export const getPeachSummaryController = async (req: Request<never, never, PermitTracking[], never>, res: Response) => {
-  const permitTracking = findPriorityPermitTracking(req.body);
+export const getPeachSummaryController = async (
+  req: Request<never, never, { permitTrackings: PermitTracking[] }, never>,
+  res: Response
+) => {
+  const permitTracking = findPriorityPermitTracking(req.body.permitTrackings);
 
   if (!permitTracking?.trackingId || !permitTracking?.sourceSystemKind?.sourceSystem) {
     throw new Problem(422, { detail: 'No PEACH-integrated tracking ID and/or system were found in the request body.' });

--- a/app/src/routes/v1/peach.ts
+++ b/app/src/routes/v1/peach.ts
@@ -17,7 +17,7 @@ router.use(requireSomeGroup);
 router.post(
   '/record',
   hasAuthorization(Resource.PEACH, Action.READ),
-  peachValidator.permitTrackings,
+  peachValidator.getPeachSummary,
   getPeachSummaryController
 );
 

--- a/app/src/validators/peach.ts
+++ b/app/src/validators/peach.ts
@@ -4,28 +4,33 @@ import { validate } from '../middleware/validation.ts';
 import { createStamps } from './stamps.ts';
 
 const schema = {
-  permitTrackings: {
-    body: Joi.array().items(
-      Joi.object({
-        trackingId: Joi.string().allow(null),
-        permitTrackingId: Joi.number().allow(null),
-        permitId: Joi.string().allow(null),
-        shownToProponent: Joi.boolean().allow(null),
-        sourceSystemKindId: Joi.number().allow(null),
-        sourceSystemKind: Joi.object({
-          sourceSystemKindId: Joi.number().required(),
-          description: Joi.string().required(),
-          integrated: Joi.boolean(),
-          kind: Joi.string().allow(null),
-          sourceSystem: Joi.string().required(),
-          ...createStamps
-        }).required(),
-        ...createStamps
-      })
-    )
+  getPeachSummary: {
+    body: Joi.object({
+      permitTrackings: Joi.array()
+        .min(1)
+        .required()
+        .items(
+          Joi.object({
+            trackingId: Joi.string().allow(null),
+            permitTrackingId: Joi.number().allow(null),
+            permitId: Joi.string().allow(null),
+            shownToProponent: Joi.boolean().allow(null),
+            sourceSystemKindId: Joi.number().allow(null),
+            sourceSystemKind: Joi.object({
+              sourceSystemKindId: Joi.number().required(),
+              description: Joi.string().required(),
+              integrated: Joi.boolean(),
+              kind: Joi.string().allow(null),
+              sourceSystem: Joi.string().required(),
+              ...createStamps
+            }).required(),
+            ...createStamps
+          })
+        )
+    })
   }
 };
 
 export default {
-  permitTrackings: validate(schema.permitTrackings)
+  getPeachSummary: validate(schema.getPeachSummary)
 };

--- a/app/tests/unit/controllers/peach.test.ts
+++ b/app/tests/unit/controllers/peach.test.ts
@@ -57,14 +57,16 @@ describe('getPeachSummaryController', () => {
 
   it('should call service, summarize, and respond with 200 and summary', async () => {
     const req = {
-      body: TEST_PERMIT_1.permitTracking
+      body: {
+        permitTrackings: TEST_PERMIT_1.permitTracking
+      }
     };
 
     getPeachRecordSpy.mockResolvedValue(TEST_PEACH_RECORD_1);
     summarizeSpy.mockReturnValue(TEST_PEACH_SUMMARY);
 
     await getPeachSummaryController(
-      req as unknown as Request<never, never, PermitTracking[], never>,
+      req as unknown as Request<never, never, { permitTrackings: PermitTracking[] }, never>,
       res as unknown as Response
     );
 
@@ -88,7 +90,7 @@ describe('getPeachSummaryController', () => {
 
     await expect(
       getPeachSummaryController(
-        req as unknown as Request<never, never, PermitTracking[], never>,
+        req as unknown as Request<never, never, { permitTrackings: PermitTracking[] }, never>,
         res as unknown as Response
       )
     ).rejects.toBeInstanceOf(Problem);
@@ -96,22 +98,24 @@ describe('getPeachSummaryController', () => {
 
   it('throws Problem(422) when summarizePeachRecord returns null-ish', async () => {
     const req = {
-      body: [
-        {
-          trackingId: TEST_PEACH_RECORD_1.record_id,
-          sourceSystemKind: {
-            sourceSystem: TEST_PEACH_RECORD_1.system_id,
-            integrated: true
+      body: {
+        permitTrackings: [
+          {
+            trackingId: TEST_PEACH_RECORD_1.record_id,
+            sourceSystemKind: {
+              sourceSystem: TEST_PEACH_RECORD_1.system_id,
+              integrated: true
+            }
           }
-        }
-      ]
+        ]
+      }
     };
 
     getPeachRecordSpy.mockResolvedValue(TEST_PEACH_RECORD_1);
     summarizeSpy.mockReturnValue(null);
 
     const error = await getPeachSummaryController(
-      req as unknown as Request<never, never, PermitTracking[], never>,
+      req as unknown as Request<never, never, { permitTrackings: PermitTracking[] }, never>,
       res as unknown as Response
     ).catch((e) => e);
 
@@ -122,20 +126,22 @@ describe('getPeachSummaryController', () => {
 
   it('throws Problem(422) when permitTracking exists but trackingId is missing', async () => {
     const req = {
-      body: [
-        {
-          sourceSystemKind: {
-            sourceSystem: TEST_PEACH_RECORD_1.system_id
+      body: {
+        permitTrackings: [
+          {
+            sourceSystemKind: {
+              sourceSystem: TEST_PEACH_RECORD_1.system_id
+            }
           }
-        }
-      ]
+        ]
+      }
     };
 
     getPeachRecordSpy.mockResolvedValue(TEST_PEACH_RECORD_1);
     summarizeSpy.mockReturnValue(TEST_PEACH_SUMMARY);
 
     const error = await getPeachSummaryController(
-      req as unknown as Request<never, never, PermitTracking[], never>,
+      req as unknown as Request<never, never, { permitTrackings: PermitTracking[] }, never>,
       res as unknown as Response
     ).catch((e) => e);
 
@@ -151,18 +157,20 @@ describe('getPeachSummaryController', () => {
 
   it('throws Problem(422) when permitTracking exists but sourceSystemKind.sourceSystem is missing', async () => {
     const req = {
-      body: [
-        {
-          trackingId: TEST_PEACH_RECORD_1.record_id
-        }
-      ]
+      body: {
+        permitTrackings: [
+          {
+            trackingId: TEST_PEACH_RECORD_1.record_id
+          }
+        ]
+      }
     };
 
     getPeachRecordSpy.mockResolvedValue(TEST_PEACH_RECORD_1);
     summarizeSpy.mockReturnValue(TEST_PEACH_SUMMARY);
 
     const error = await getPeachSummaryController(
-      req as unknown as Request<never, never, PermitTracking[], never>,
+      req as unknown as Request<never, never, { permitTrackings: PermitTracking[] }, never>,
       res as unknown as Response
     ).catch((e) => e);
 

--- a/frontend/src/components/authorization/AuthorizationForm.vue
+++ b/frontend/src/components/authorization/AuthorizationForm.vue
@@ -179,7 +179,7 @@ async function getPeachSummary(permitTrackings: PermitTracking[]) {
         sourceSystemKind: omit(found, ['permitTypeIds']) as SourceSystemKind
       };
     });
-    const peachSummary = await peachService.getPeachSummary({ data });
+    const peachSummary = await peachService.getPeachSummary({ permitTrackings: data });
     return peachSummary;
   } catch (e) {
     if (isAxiosError(e)) {

--- a/frontend/src/types/api/requests.ts
+++ b/frontend/src/types/api/requests.ts
@@ -431,7 +431,7 @@ export interface ListPermissionsRequest {
 }
 
 export interface GetPeachSummaryRequest {
-  data: PermitTracking[];
+  permitTrackings: PermitTracking[];
 }
 
 export interface GetPidsRequest {

--- a/frontend/tests/unit/service/peachService.spec.ts
+++ b/frontend/tests/unit/service/peachService.spec.ts
@@ -21,7 +21,7 @@ describe('peach service', () => {
   describe('getPeachSummary', () => {
     it('returns a peach summary', async () => {
       const request: GetPeachSummaryRequest = {
-        data: [
+        permitTrackings: [
           {
             permitTrackingId: 'tracking-1' as never,
             permitId: 'permit-1' as never,
@@ -55,7 +55,7 @@ describe('peach service', () => {
 
     it('returns an empty summary when no permit tracking records are provided', async () => {
       const request: GetPeachSummaryRequest = {
-        data: []
+        permitTrackings: []
       };
 
       const response = {
@@ -76,7 +76,7 @@ describe('peach service', () => {
 
     it('propagates errors', async () => {
       const request: GetPeachSummaryRequest = {
-        data: [
+        permitTrackings: [
           {
             shownToProponent: true,
             trackingId: 'TRACK-001'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

[PADS-850](https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-850)

Fixed a schema mismatch by wrapping the request array inside a `permitTrackings` object property. Updated the request interface and call site to match the expected schema.
- Backend: Updated controller and validator to expect the new structure.
- Frontend: Updated interface and API call to match.
Users (Navs) unable to link PEACH integrated permit trackings.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)