### PR TITLE
chore(ci): drop node 22.x support from unit-test.yaml

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -54,7 +54,6 @@ jobs:
       fail-fast: true
       matrix:
         node-version:
-          - "22.x"
           - "24.x"
     steps:
       - name: Checkout Repository
@@ -122,7 +121,6 @@ jobs:
       fail-fast: true
       matrix:
         node-version:
-          - "22.x"
           - "24.x"
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Drops node 22.x support from unit-test.yaml matrixes.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->