### PR TITLE
fix: email templates not showing permit type name

### DIFF
--- a/app/peachSync.ts
+++ b/app/peachSync.ts
@@ -13,7 +13,7 @@ async function syncPeachToPcns() {
   if (!state.features.peach) return;
 
   await unitOfWork.execute(
-    async ({ electrificationProject, generalProject, housingProject, permit, permitNote, user }) => {
+    async ({ electrificationProject, generalProject, housingProject, permit, permitNote, permitType, user }) => {
       const started = Date.now();
       let updatedPermitsWithNotes: UpdatedPermitWithNote[];
 
@@ -37,7 +37,7 @@ async function syncPeachToPcns() {
         for (const permitWithNote of updatedPermitsWithNotes) {
           const { permit, note } = permitWithNote;
           await sendPermitUpdateNotifications(
-            { electrificationProject, generalProject, housingProject, permitNote, user },
+            { electrificationProject, generalProject, housingProject, permitNote, permitType, user },
             permit,
             true,
             note

--- a/app/src/domains/permit.ts
+++ b/app/src/domains/permit.ts
@@ -40,12 +40,25 @@ export const listPeachIntegratedTrackings = async (repositories: Pick<Repositori
 
 /**
  * Sends out an email notification for the given update email params
+ * @param repositories - The required repositories
  * @param params Email information for template and recipients
  */
-export const sendPermitUpdateEmail = async (params: PermitUpdateEmailParams) => {
+export const sendPermitUpdateEmail = async (
+  repositories: Pick<Repositories, 'permitType'>,
+  params: PermitUpdateEmailParams
+) => {
   const { permit, initiative, dearName, projectId, toEmails, emailTemplate } = params;
   const { permitId, activityId } = permit;
-  const permitName = permit.permitType?.name;
+
+  let permitName = permit.permitType?.name;
+  if (!permitName) {
+    const permitType = await repositories.permitType.findFirst({
+      select: { name: true },
+      where: { permitTypeId: permit.permitTypeId }
+    });
+    permitName = permitType?.name;
+  }
+
   const submittedDate = formatDateOnly(permit.submittedDate);
 
   const nrmPermitEmail: string = config.get('server.ches.submission.cc');
@@ -84,7 +97,7 @@ export const sendPermitUpdateEmail = async (params: PermitUpdateEmailParams) => 
  * @param note A permit note to be used in permit note creation, if given
  */
 export const sendPermitUpdateNotifications = async (
-  repositories: Pick<Repositories, ProjectRepositoryKeys | 'permitNote' | 'user'>,
+  repositories: Pick<Repositories, ProjectRepositoryKeys | 'permitNote' | 'permitType' | 'user'>,
   permit: Permit,
   fromPeachSync: boolean,
   note?: string
@@ -167,6 +180,6 @@ export const sendPermitUpdateNotifications = async (
 
   // Send out permit update emails
   for (const emailJob of permitUpdateEmails) {
-    await sendPermitUpdateEmail(emailJob);
+    await sendPermitUpdateEmail({ permitType: repositories.permitType }, emailJob);
   }
 };

--- a/app/src/services/permit.ts
+++ b/app/src/services/permit.ts
@@ -185,6 +185,7 @@ export const upsertPermitService = async (
       permit,
       permitNote,
       permitTracking,
+      permitType,
       sourceSystemKind,
       user
     }) => {
@@ -275,7 +276,7 @@ export const upsertPermitService = async (
             ? `This application is ${data.state.toLocaleLowerCase()} in the ${data.stage.toLocaleLowerCase()}.`
             : permitNoteText;
           await sendPermitUpdateNotifications(
-            { electrificationProject, generalProject, housingProject, permitNote, user },
+            { electrificationProject, generalProject, housingProject, permitNote, permitType, user },
             data,
             false,
             note

--- a/app/tests/unit/domains/permit.test.ts
+++ b/app/tests/unit/domains/permit.test.ts
@@ -105,7 +105,7 @@ describe('permit domain', () => {
         emailTemplate: vi.fn().mockReturnValue('<html>Email body</html>')
       };
 
-      await sendPermitUpdateEmail(params);
+      await sendPermitUpdateEmail(mockRepos, params);
 
       expect(emailSpy).toHaveBeenCalledWith({
         to: ['recipient@example.com'],
@@ -147,7 +147,7 @@ describe('permit domain', () => {
         emailTemplate: vi.fn().mockReturnValue('body')
       };
 
-      await sendPermitUpdateEmail(params);
+      await sendPermitUpdateEmail(mockRepos, params);
 
       const emailCall = emailSpy.mock.calls[0]?.[0];
       expect(emailCall?.subject).toBe('Updates for Housing project ACTI1234, Permit');


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

`sendPermitUpdateEmail()` now takes the `permitType` repository and does a lookup if `permitType.name` is not give as part of the permit.

https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-872

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->