### PR TITLE
fix(api): correct HTTP verb usage

### DIFF
--- a/app/src/controllers/contact.ts
+++ b/app/src/controllers/contact.ts
@@ -51,22 +51,24 @@ export const matchContactsController = async (
 };
 
 export const searchContactsController = async (
-  req: Request<never, never, ContactSearchParameters | undefined, never>,
+  req: Request<never, never, ContactSearchParameters, never>,
   res: Response<Contact[]>
 ) => {
-  const contactIds = mixedQueryToArray(req.body?.contactId);
-  const userIds = mixedQueryToArray(req.body?.userId);
+  req.body ??= {};
+
+  const contactIds = mixedQueryToArray(req.body.contactId);
+  const userIds = mixedQueryToArray(req.body.userId);
 
   const response = await searchContactsService({
     userId: userIds ? userIds.map((id) => addDashesToUuid(id)) : userIds,
     contactId: contactIds ? contactIds.map((id) => addDashesToUuid(id)) : contactIds,
-    email: req.body?.email,
-    firstName: req.body?.firstName,
-    lastName: req.body?.lastName,
-    contactApplicantRelationship: req.body?.contactApplicantRelationship,
-    phoneNumber: req.body?.phoneNumber,
-    initiative: req.body?.initiative,
-    includeActivities: isTruthy(req.body?.includeActivities)
+    email: req.body.email,
+    firstName: req.body.firstName,
+    lastName: req.body.lastName,
+    contactApplicantRelationship: req.body.contactApplicantRelationship,
+    phoneNumber: req.body.phoneNumber,
+    initiative: req.body.initiative,
+    includeActivities: isTruthy(req.body.includeActivities)
   });
 
   res.status(200).json(response);

--- a/app/src/controllers/electrificationProject.ts
+++ b/app/src/controllers/electrificationProject.ts
@@ -6,15 +6,14 @@ import {
   getElectrificationProjectStatisticsService,
   listElectrificationProjectActivityIdsService,
   listElectrificationProjectsService,
+  patchElectrificationProjectService,
   searchElectrificationProjects,
-  submitElectrificationProjectDraftService,
-  updateElectrificationProjectService
+  submitElectrificationProjectDraftService
 } from '../services/electrificationProject.ts';
 import { Initiative } from '../utils/enums/application.ts';
 import { DraftCode } from '../utils/enums/projectCommon.ts';
 import { isTruthy } from '../utils/utils.ts';
 
-import type { Prisma } from '@prisma/client';
 import type { Request, Response } from 'express';
 import type {
   Draft,
@@ -23,6 +22,7 @@ import type {
   ElectrificationProjectSearchParameters,
   ElectrificationProjectStatistics,
   LocalContext,
+  PatchElectrificationProjectRequest,
   StatisticsFilters
 } from '../types/index.ts';
 
@@ -86,20 +86,11 @@ export const searchElectrificationProjectsController = async (
   res.status(200).json(response);
 };
 
-export const updateElectrificationProjectController = async (
-  req: Request<
-    { electrificationProjectId: string },
-    never,
-    Omit<Prisma.electrification_projectUpdateInput, 'electrificationProjectId'>
-  >,
+export const patchElectrificationProjectController = async (
+  req: Request<{ electrificationProjectId: string }, never, PatchElectrificationProjectRequest>,
   res: Response
 ) => {
-  const response = await updateElectrificationProjectService(
-    {
-      ...req.body
-    },
-    req.params.electrificationProjectId
-  );
+  const response = await patchElectrificationProjectService(req.params.electrificationProjectId, req.body);
   res.status(200).json(response);
 };
 

--- a/app/src/controllers/electrificationProject.ts
+++ b/app/src/controllers/electrificationProject.ts
@@ -19,10 +19,10 @@ import type {
   Draft,
   ElectrificationProject,
   ElectrificationProjectIntake,
-  ElectrificationProjectSearchParameters,
   ElectrificationProjectStatistics,
   LocalContext,
   PatchElectrificationProjectRequest,
+  SearchElectrificationProjectRequest,
   StatisticsFilters
 } from '../types/index.ts';
 
@@ -76,7 +76,7 @@ export const listElectrificationProjectsController = async (
 };
 
 export const searchElectrificationProjectsController = async (
-  req: Request<never, never, ElectrificationProjectSearchParameters | undefined, never>,
+  req: Request<never, never, SearchElectrificationProjectRequest | undefined, never>,
   res: Response<ElectrificationProject[], LocalContext>
 ) => {
   const response = await searchElectrificationProjects(res.locals.currentAuthorization, res.locals.currentContext, {

--- a/app/src/controllers/electrificationProject.ts
+++ b/app/src/controllers/electrificationProject.ts
@@ -76,12 +76,14 @@ export const listElectrificationProjectsController = async (
 };
 
 export const searchElectrificationProjectsController = async (
-  req: Request<never, never, SearchElectrificationProjectRequest | undefined, never>,
+  req: Request<never, never, SearchElectrificationProjectRequest>,
   res: Response<ElectrificationProject[], LocalContext>
 ) => {
+  req.body ??= {};
+
   const response = await searchElectrificationProjects(res.locals.currentAuthorization, res.locals.currentContext, {
     ...req.body,
-    includeUser: isTruthy(req.body?.includeUser)
+    includeUser: isTruthy(req.body.includeUser)
   });
   res.status(200).json(response);
 };

--- a/app/src/controllers/enquiry.ts
+++ b/app/src/controllers/enquiry.ts
@@ -11,16 +11,17 @@ import { isTruthy } from '../utils/utils.ts';
 
 import type { Request, Response } from 'express';
 import type {
+  CreateEnquiryResponse,
   Enquiry,
   EnquiryIntake,
-  EnquirySearchParameters,
   LocalContext,
-  PatchEnquiryRequest
+  PatchEnquiryRequest,
+  SearchEnquiriesRequest
 } from '../types/index.ts';
 
 export const createEnquiryController = async (
   req: Request<never, never, EnquiryIntake>,
-  res: Response<Enquiry, LocalContext>
+  res: Response<CreateEnquiryResponse, LocalContext>
 ) => {
   // Provide an empty body if POST body is given undefined
   req.body ??= {} as EnquiryIntake;
@@ -59,15 +60,17 @@ export const listRelatedEnquiriesController = async (
 };
 
 export const searchEnquiriesController = async (
-  req: Request<never, never, EnquirySearchParameters | undefined, never>,
+  req: Request<never, never, SearchEnquiriesRequest, never>,
   res: Response<Enquiry[], LocalContext>
 ) => {
+  req.body ??= {};
+
   const response = await searchEnquiriesService(
     res.locals.currentAuthorization,
     res.locals.currentContext,
     {
       ...req.body,
-      includeUser: isTruthy(req.body?.includeUser)
+      includeUser: isTruthy(req.body.includeUser)
     },
     res.locals.currentContext.initiative
   );

--- a/app/src/controllers/enquiry.ts
+++ b/app/src/controllers/enquiry.ts
@@ -4,14 +4,19 @@ import {
   getEnquiryService,
   listEnquiriesService,
   listRelatedEnquiriesService,
-  searchEnquiriesService,
-  updateEnquiryService
+  patchEnquiryService,
+  searchEnquiriesService
 } from '../services/enquiry.ts';
 import { isTruthy } from '../utils/utils.ts';
 
-import type { Prisma } from '@prisma/client';
 import type { Request, Response } from 'express';
-import type { Enquiry, EnquiryIntake, EnquirySearchParameters, LocalContext } from '../types/index.ts';
+import type {
+  Enquiry,
+  EnquiryIntake,
+  EnquirySearchParameters,
+  LocalContext,
+  PatchEnquiryRequest
+} from '../types/index.ts';
 
 export const createEnquiryController = async (
   req: Request<never, never, EnquiryIntake>,
@@ -69,10 +74,10 @@ export const searchEnquiriesController = async (
   res.status(200).json(response);
 };
 
-export const updateEnquiryController = async (
-  req: Request<{ enquiryId: string }, never, Omit<Prisma.enquiryUpdateInput, 'enquiryId'>>,
+export const patchEnquiryController = async (
+  req: Request<{ enquiryId: string }, never, PatchEnquiryRequest>,
   res: Response
 ) => {
-  const response = await updateEnquiryService(req.body, req.params.enquiryId);
+  const response = await patchEnquiryService(req.params.enquiryId, req.body);
   res.status(200).json(response);
 };

--- a/app/src/controllers/generalProject.ts
+++ b/app/src/controllers/generalProject.ts
@@ -66,12 +66,14 @@ export const listGeneralProjectsController = async (_req: Request, res: Response
 };
 
 export const searchGeneralProjectsController = async (
-  req: Request<never, never, SearchGeneralProjectRequest | undefined, never>,
+  req: Request<never, never, SearchGeneralProjectRequest>,
   res: Response<GeneralProject[], LocalContext>
 ) => {
+  req.body ??= {};
+
   const response = await searchGeneralProjects(res.locals.currentAuthorization, res.locals.currentContext, {
     ...req.body,
-    includeUser: isTruthy(req.body?.includeUser)
+    includeUser: isTruthy(req.body.includeUser)
   });
   res.status(200).json(response);
 };

--- a/app/src/controllers/generalProject.ts
+++ b/app/src/controllers/generalProject.ts
@@ -19,9 +19,9 @@ import type {
   Draft,
   GeneralProject,
   GeneralProjectIntake,
-  GeneralProjectSearchParameters,
   LocalContext,
   PatchGeneralProjectRequest,
+  SearchGeneralProjectRequest,
   StatisticsFilters
 } from '../types/index.ts';
 
@@ -66,7 +66,7 @@ export const listGeneralProjectsController = async (_req: Request, res: Response
 };
 
 export const searchGeneralProjectsController = async (
-  req: Request<never, never, GeneralProjectSearchParameters | undefined, never>,
+  req: Request<never, never, SearchGeneralProjectRequest | undefined, never>,
   res: Response<GeneralProject[], LocalContext>
 ) => {
   const response = await searchGeneralProjects(res.locals.currentAuthorization, res.locals.currentContext, {

--- a/app/src/controllers/generalProject.ts
+++ b/app/src/controllers/generalProject.ts
@@ -6,15 +6,14 @@ import {
   getGeneralProjectStatisticsService,
   listGeneralProjectActivityIdsService,
   listGeneralProjectsService,
+  patchGeneralProjectService,
   searchGeneralProjects,
-  submitGeneralProjectDraftService,
-  updateGeneralProjectService
+  submitGeneralProjectDraftService
 } from '../services/generalProject.ts';
 import { Initiative } from '../utils/enums/application.ts';
 import { DraftCode } from '../utils/enums/projectCommon.ts';
 import { isTruthy } from '../utils/utils.ts';
 
-import type { Prisma } from '@prisma/client';
 import type { Request, Response } from 'express';
 import type {
   Draft,
@@ -22,6 +21,7 @@ import type {
   GeneralProjectIntake,
   GeneralProjectSearchParameters,
   LocalContext,
+  PatchGeneralProjectRequest,
   StatisticsFilters
 } from '../types/index.ts';
 
@@ -76,16 +76,11 @@ export const searchGeneralProjectsController = async (
   res.status(200).json(response);
 };
 
-export const updateGeneralProjectController = async (
-  req: Request<{ generalProjectId: string }, never, Omit<Prisma.general_projectUpdateInput, 'generalProjectId'>>,
+export const patchGeneralProjectController = async (
+  req: Request<{ generalProjectId: string }, never, PatchGeneralProjectRequest>,
   res: Response
 ) => {
-  const response = await updateGeneralProjectService(
-    {
-      ...req.body
-    },
-    req.params.generalProjectId
-  );
+  const response = await patchGeneralProjectService(req.params.generalProjectId, req.body);
   res.status(200).json(response);
 };
 

--- a/app/src/controllers/housingProject.ts
+++ b/app/src/controllers/housingProject.ts
@@ -6,15 +6,14 @@ import {
   getHousingProjectStatisticsService,
   listHousingProjectActivityIdsService,
   listHousingProjectsService,
+  patchHousingProjectService,
   searchHousingProjects,
-  submitHousingProjectDraftService,
-  updateHousingProjectService
+  submitHousingProjectDraftService
 } from '../services/housingProject.ts';
 import { BasicResponse, Initiative } from '../utils/enums/application.ts';
 import { DraftCode } from '../utils/enums/projectCommon.ts';
 import { isTruthy } from '../utils/utils.ts';
 
-import type { Prisma } from '@prisma/client';
 import type { Request, Response } from 'express';
 import type {
   Draft,
@@ -23,6 +22,7 @@ import type {
   HousingProjectSearchParameters,
   HousingProjectStatistics,
   LocalContext,
+  PatchHousingProjectRequest,
   StatisticsFilters
 } from '../types/index.ts';
 
@@ -80,22 +80,19 @@ export const searchHousingProjectsController = async (
   res.status(200).json(response);
 };
 
-export const updateHousingProjectController = async (
-  req: Request<{ housingProjectId: string }, never, Omit<Prisma.housing_projectUpdateInput, 'housingProjectId'>>,
+export const patchHousingProjectController = async (
+  req: Request<{ housingProjectId: string }, never, PatchHousingProjectRequest>,
   res: Response
 ) => {
-  const response = await updateHousingProjectService(
-    {
-      ...req.body,
-      financiallySupported: [
-        req.body.financiallySupportedBc,
-        req.body.financiallySupportedIndigenous,
-        req.body.financiallySupportedNonProfit,
-        req.body.financiallySupportedHousingCoop
-      ].includes(BasicResponse.YES)
-    },
-    req.params.housingProjectId
-  );
+  const response = await patchHousingProjectService(req.params.housingProjectId, {
+    ...req.body,
+    financiallySupported: [
+      req.body.financiallySupportedBc,
+      req.body.financiallySupportedIndigenous,
+      req.body.financiallySupportedNonProfit,
+      req.body.financiallySupportedHousingCoop
+    ].includes(BasicResponse.YES)
+  });
   res.status(200).json(response);
 };
 

--- a/app/src/controllers/housingProject.ts
+++ b/app/src/controllers/housingProject.ts
@@ -70,12 +70,14 @@ export const listHousingProjectsController = async (_req: Request, res: Response
 };
 
 export const searchHousingProjectsController = async (
-  req: Request<never, never, SearchHousingProjectRequest | undefined, never>,
+  req: Request<never, never, SearchHousingProjectRequest>,
   res: Response<HousingProject[], LocalContext>
 ) => {
+  req.body ??= {};
+
   const response = await searchHousingProjects(res.locals.currentAuthorization, res.locals.currentContext, {
     ...req.body,
-    includeUser: isTruthy(req.body?.includeUser)
+    includeUser: isTruthy(req.body.includeUser)
   });
   res.status(200).json(response);
 };

--- a/app/src/controllers/housingProject.ts
+++ b/app/src/controllers/housingProject.ts
@@ -10,7 +10,7 @@ import {
   searchHousingProjects,
   submitHousingProjectDraftService
 } from '../services/housingProject.ts';
-import { BasicResponse, Initiative } from '../utils/enums/application.ts';
+import { Initiative } from '../utils/enums/application.ts';
 import { DraftCode } from '../utils/enums/projectCommon.ts';
 import { isTruthy } from '../utils/utils.ts';
 
@@ -86,15 +86,7 @@ export const patchHousingProjectController = async (
   req: Request<{ housingProjectId: string }, never, PatchHousingProjectRequest>,
   res: Response
 ) => {
-  const response = await patchHousingProjectService(req.params.housingProjectId, {
-    ...req.body,
-    financiallySupported: [
-      req.body.financiallySupportedBc,
-      req.body.financiallySupportedIndigenous,
-      req.body.financiallySupportedNonProfit,
-      req.body.financiallySupportedHousingCoop
-    ].includes(BasicResponse.YES)
-  });
+  const response = await patchHousingProjectService(req.params.housingProjectId, req.body);
   res.status(200).json(response);
 };
 

--- a/app/src/controllers/housingProject.ts
+++ b/app/src/controllers/housingProject.ts
@@ -19,8 +19,8 @@ import type {
   Draft,
   HousingProject,
   HousingProjectIntake,
-  HousingProjectSearchParameters,
   HousingProjectStatistics,
+  SearchHousingProjectRequest,
   LocalContext,
   PatchHousingProjectRequest,
   StatisticsFilters
@@ -70,7 +70,7 @@ export const listHousingProjectsController = async (_req: Request, res: Response
 };
 
 export const searchHousingProjectsController = async (
-  req: Request<never, never, HousingProjectSearchParameters | undefined, never>,
+  req: Request<never, never, SearchHousingProjectRequest | undefined, never>,
   res: Response<HousingProject[], LocalContext>
 ) => {
   const response = await searchHousingProjects(res.locals.currentAuthorization, res.locals.currentContext, {

--- a/app/src/controllers/noteHistory.ts
+++ b/app/src/controllers/noteHistory.ts
@@ -3,13 +3,12 @@ import {
   deleteNoteHistoryService,
   listBringForwardsService,
   listNoteHistoriesService,
-  updateNoteHistoryService
+  patchNoteHistoryService
 } from '../services/noteHistory.ts';
 import { Initiative } from '../utils/enums/application.ts';
 
 import type { Request, Response } from 'express';
-import type { BringForward, LocalContext, NoteHistory } from '../types/index.ts';
-import type { Resource } from '../utils/enums/application.ts';
+import type { BringForward, LocalContext, NoteHistory, PatchNoteHistoryRequest } from '../types/index.ts';
 import type { BringForwardType } from '../utils/enums/projectCommon.ts';
 
 export const createNoteHistoryController = async (
@@ -46,15 +45,16 @@ export const listNoteHistoriesController = async (
   res.status(200).json(response);
 };
 
-export const updateNoteHistoryController = async (
-  req: Request<{ noteHistoryId: string }, never, NoteHistory & { note: string | undefined; resource: Resource }>,
+export const patchNoteHistoryController = async (
+  req: Request<{ noteHistoryId: string }, never, PatchNoteHistoryRequest>,
   res: Response<NoteHistory, LocalContext>
 ) => {
-  const { note, resource, ...history } = req.body;
-  const response = await updateNoteHistoryService(
+  const { note, resource, ...data } = req.body;
+  const response = await patchNoteHistoryService(
+    req.params.noteHistoryId,
     res.locals.currentAuthorization,
     res.locals.currentContext,
-    { ...history, noteHistoryId: req.params.noteHistoryId },
+    data,
     note,
     resource
   );

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -251,71 +251,53 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /contact/search:
-    get:
+    post:
       summary: Search contacts
       description: Returns a list of contacts based on the given queries
       operationId: searchContacts
       tags:
         - Contact
-      parameters:
-        - in: query
-          name: contactApplicantRelationship
-          required: false
-          schema:
-            type: string
-            description: The contact applicant relationship type to filter on
-            example: Property owner
-        - in: query
-          name: contactPreference
-          required: false
-          schema:
-            type: string
-            description: The Contact's contact preference
-            example: Email
-        - in: query
-          name: contactId
-          required: false
-          schema:
-            type: array
-            description: The Contact IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-ContactId'
-        - in: query
-          name: email
-          required: false
-          schema:
-            type: string
-            description: The Contact's email to filter on
-            example: JaneDoe@email.com
-        - in: query
-          name: firstName
-          required: false
-          schema:
-            type: string
-            description: The Contact's firstName to filter on
-            example: Jane
-        - in: query
-          name: lastName
-          required: false
-          schema:
-            type: string
-            description: The Contact's lastName to filter on
-            example: Doe
-        - in: query
-          name: phoneNumber
-          required: false
-          schema:
-            type: string
-            description: The Contact's phoneNumber to filter on
-            example: (123) 456-7890
-        - in: query
-          name: userId
-          required: false
-          schema:
-            type: array
-            description: The Contact User IDs to filter on
-            items:
-              $ref: '#/components/parameters/Query-UserId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                contactApplicantRelationship:
+                  type: string
+                  description: The contact applicant relationship type to filter on
+                  example: Property owner
+                contactPreference:
+                  type: string
+                  description: The Contact's contact preference
+                  example: Email
+                contactId:
+                  type: array
+                  description: The Contact IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-ContactId'
+                email:
+                  type: string
+                  description: The Contact's email to filter on
+                  example: JaneDoe@email.com
+                firstName:
+                  type: string
+                  description: The Contact's firstName to filter on
+                  example: Jane
+                lastName:
+                  type: string
+                  description: The Contact's lastName to filter on
+                  example: Doe
+                phoneNumber:
+                  type: string
+                  description: The Contact's phoneNumber to filter on
+                  example: (123) 456-7890
+                userId:
+                  type: array
+                  description: The Contact User IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Query-UserId'
       responses:
         '200':
           description: A list of contacts matching the search criteria
@@ -637,38 +619,37 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /electrification/enquiry/search:
-    get:
+    post:
       summary: Search enquiries
       description: Returns a list of enquiries based on the given queries
       operationId: searchElectrificationEnquiries
       tags:
         - Electrification Enquiry
-      parameters:
-        - $ref: '#/components/parameters/Query-IncludeUser'
-        - in: query
-          name: activityId
-          required: false
-          schema:
-            type: array
-            description: The Activity IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-ActivityId'
-        - in: query
-          name: createdBy
-          required: false
-          schema:
-            type: array
-            description: The User IDs to filter on
-            items:
-              $ref: '#/components/parameters/Query-CreatedBy'
-        - in: query
-          name: enquiryId
-          required: false
-          schema:
-            type: array
-            description: The Enquiry IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-EnquiryId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                includeUser:
+                  type: boolean
+                  description: Whether to include User data with each entity being returned by the results.
+                activityId:
+                  type: array
+                  description: The Activity IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-ActivityId'
+                createdBy:
+                  type: array
+                  description: The User IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Query-CreatedBy'
+                enquiryId:
+                  type: array
+                  description: The Enquiry IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-EnquiryId'
       responses:
         '200':
           description: A list of enquiries matching the search criteria
@@ -1210,38 +1191,37 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /electrification/project/search:
-    get:
+    post:
       summary: Search electrification projects
       description: Returns a list of electrification projects based on the given queries
       operationId: searchElectrificationProjects
       tags:
         - Electrification Project
-      parameters:
-        - $ref: '#/components/parameters/Query-IncludeUser'
-        - in: query
-          name: activityId
-          required: false
-          schema:
-            type: array
-            description: The Activity IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-ActivityId'
-        - in: query
-          name: createdBy
-          required: false
-          schema:
-            type: array
-            description: The User IDs to filter on
-            items:
-              $ref: '#/components/parameters/Query-CreatedBy'
-        - in: query
-          name: electrificationProjectId
-          required: false
-          schema:
-            type: array
-            description: The Electrification Project IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-ElectrificationProjectId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                includeUser:
+                  type: boolean
+                  description: Whether to include User data with each entity being returned by the results.
+                activityId:
+                  type: array
+                  description: The Activity IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-ActivityId'
+                createdBy:
+                  type: array
+                  description: The User IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Query-CreatedBy'
+                electrificationProjectId:
+                  type: array
+                  description: The Electrification Project IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-ElectrificationProjectId'
       responses:
         '200':
           description: A list of electrification projects matching the search criteria
@@ -1639,38 +1619,37 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /general/enquiry/search:
-    get:
+    post:
       summary: Search enquiries
       description: Returns a list of enquiries based on the given queries
       operationId: searchGeneralEnquiries
       tags:
         - General Enquiry
-      parameters:
-        - $ref: '#/components/parameters/Query-IncludeUser'
-        - in: query
-          name: activityId
-          required: false
-          schema:
-            type: array
-            description: The Activity IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-ActivityId'
-        - in: query
-          name: createdBy
-          required: false
-          schema:
-            type: array
-            description: The User IDs to filter on
-            items:
-              $ref: '#/components/parameters/Query-CreatedBy'
-        - in: query
-          name: enquiryId
-          required: false
-          schema:
-            type: array
-            description: The Enquiry IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-EnquiryId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                includeUser:
+                  type: boolean
+                  description: Whether to include User data with each entity being returned by the results.
+                activityId:
+                  type: array
+                  description: The Activity IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-ActivityId'
+                createdBy:
+                  type: array
+                  description: The User IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Query-CreatedBy'
+                enquiryId:
+                  type: array
+                  description: The Enquiry IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-EnquiryId'
       responses:
         '200':
           description: A list of enquiries matching the search criteria
@@ -2123,46 +2102,42 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /general/project/search:
-    get:
+    post:
       summary: Search general projects
       description: Returns a list of general projects based on the given queries
       operationId: searchGeneralProjects
       tags:
         - General Project
-      parameters:
-        - $ref: '#/components/parameters/Query-IncludeUser'
-        - in: query
-          name: activityId
-          required: false
-          schema:
-            type: array
-            description: The Activity IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-ActivityId'
-        - in: query
-          name: createdBy
-          required: false
-          schema:
-            type: array
-            description: The User IDs to filter on
-            items:
-              $ref: '#/components/parameters/Query-CreatedBy'
-        - in: query
-          name: generalProjectId
-          required: false
-          schema:
-            type: array
-            description: The General Project IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-GeneralProjectId'
-        - in: query
-          name: submissionType
-          required: false
-          schema:
-            type: array
-            description: The general submission types to filter on
-            items:
-              $ref: '#/components/parameters/Query-SubmissionType'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                includeUser:
+                  type: boolean
+                  description: Whether to include User data with each entity being returned by the results.
+                activityId:
+                  type: array
+                  description: The Activity IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-ActivityId'
+                createdBy:
+                  type: array
+                  description: The User IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Query-CreatedBy'
+                generalProjectId:
+                  type: array
+                  description: The General Project IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-GeneralProjectId'
+                submissionType:
+                  type: array
+                  description: The general submission types to filter on
+                  items:
+                    $ref: '#/components/parameters/Query-SubmissionType'
       responses:
         '200':
           description: A list of general projects matching the search criteria
@@ -2560,38 +2535,37 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /housing/enquiry/search:
-    get:
+    post:
       summary: Search enquiries
       description: Returns a list of enquiries based on the given queries
       operationId: searchHousingEnquiries
       tags:
         - Housing Enquiry
-      parameters:
-        - $ref: '#/components/parameters/Query-IncludeUser'
-        - in: query
-          name: activityId
-          required: false
-          schema:
-            type: array
-            description: The Activity IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-ActivityId'
-        - in: query
-          name: createdBy
-          required: false
-          schema:
-            type: array
-            description: The User IDs to filter on
-            items:
-              $ref: '#/components/parameters/Query-CreatedBy'
-        - in: query
-          name: enquiryId
-          required: false
-          schema:
-            type: array
-            description: The Enquiry IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-EnquiryId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                includeUser:
+                  type: boolean
+                  description: Whether to include User data with each entity being returned by the results.
+                activityId:
+                  type: array
+                  description: The Activity IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-ActivityId'
+                createdBy:
+                  type: array
+                  description: The User IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Query-CreatedBy'
+                enquiryId:
+                  type: array
+                  description: The Enquiry IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-EnquiryId'
       responses:
         '200':
           description: A list of enquiries matching the search criteria
@@ -3132,46 +3106,42 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /housing/project/search:
-    get:
+    post:
       summary: Search housing projects
       description: Returns a list of housing projects based on the given queries
       operationId: searchHousingProjects
       tags:
         - Housing Project
-      parameters:
-        - $ref: '#/components/parameters/Query-IncludeUser'
-        - in: query
-          name: activityId
-          required: false
-          schema:
-            type: array
-            description: The Activity IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-ActivityId'
-        - in: query
-          name: createdBy
-          required: false
-          schema:
-            type: array
-            description: The User IDs to filter on
-            items:
-              $ref: '#/components/parameters/Query-CreatedBy'
-        - in: query
-          name: housingProjectId
-          required: false
-          schema:
-            type: array
-            description: The Housing Project IDs to filter on
-            items:
-              $ref: '#/components/parameters/Path-HousingProjectId'
-        - in: query
-          name: submissionType
-          required: false
-          schema:
-            type: array
-            description: The housing submission types to filter on
-            items:
-              $ref: '#/components/parameters/Query-SubmissionType'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                includeUser:
+                  type: boolean
+                  description: Whether to include User data with each entity being returned by the results.
+                activityId:
+                  type: array
+                  description: The Activity IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-ActivityId'
+                createdBy:
+                  type: array
+                  description: The User IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Query-CreatedBy'
+                housingProjectId:
+                  type: array
+                  description: The Housing Project IDs to filter on
+                  items:
+                    $ref: '#/components/parameters/Path-HousingProjectId'
+                submissionType:
+                  type: array
+                  description: The housing submission types to filter on
+                  items:
+                    $ref: '#/components/parameters/Query-SubmissionType'
       responses:
         '200':
           description: A list of housing projects matching the search criteria
@@ -3372,13 +3342,62 @@ paths:
                 $ref: '#/components/schemas/DB-SourceSystemKind'
         "401":
           $ref: "#/components/responses/Unauthorized"
-  /user:
-    get:
+  /user/search:
+    post:
       summary: Search users
       description: Gets a list of users based on given parameters
       operationId: searchUsers
       tags:
         - User
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: array
+                  description: The User IDs to filter on
+                  items:
+                    type: string
+                    format: uuid
+                idp:
+                  type: array
+                  description: The identity provider kinds to filter on
+                  items:
+                    type: string
+                sub:
+                  type: string
+                  description: The IDIR/BCeID subject identifier to filter on
+                email:
+                  type: string
+                  description: The User's email to filter on
+                firstName:
+                  type: string
+                  description: The User's firstName to filter on
+                fullName:
+                  type: string
+                  description: The User's full name to filter on
+                lastName:
+                  type: string
+                  description: The User's lastName to filter on
+                active:
+                  type: boolean
+                  description: Whether to filter on active users only
+                group:
+                  type: array
+                  description: The group names to filter on
+                  items:
+                    type: string
+                includeUserGroups:
+                  type: boolean
+                  description: Whether to include group data with each user being returned
+                initiative:
+                  type: array
+                  description: The initiatives to filter on
+                  items:
+                    type: string
       responses:
         '200':
           description: Users

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -559,9 +559,9 @@ paths:
           $ref: '#/components/responses/NotFound'
         default:
           $ref: '#/components/responses/Error'
-    put:
-      summary: Update an enquiry
-      operationId: updateElectrificationEnquiry
+    patch:
+      summary: Partially update an enquiry
+      operationId: patchElectrificationEnquiry
       tags:
         - Electrification Enquiry
       parameters:
@@ -571,7 +571,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DB-Enquiry'
+              $ref: '#/components/schemas/Request-EnquiryPatch'
       responses:
         '200':
           description: Enquiry updated successfully
@@ -1023,9 +1023,9 @@ paths:
           $ref: "#/components/responses/UnprocessableEntity"
         default:
           $ref: '#/components/responses/Error'
-    put:
-      summary: Update a electrification project
-      operationId: updateElectrificationProject
+    patch:
+      summary: Partially update a electrification project
+      operationId: patchElectrificationProject
       tags:
         - Electrification Project
       parameters:
@@ -1035,7 +1035,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Request-ElectrificationProjectUpdate'
+              $ref: '#/components/schemas/Request-ElectrificationProjectPatch'
       responses:
         '200':
           description: Electrification Project updated successfully
@@ -1535,9 +1535,9 @@ paths:
           $ref: '#/components/responses/NotFound'
         default:
           $ref: '#/components/responses/Error'
-    put:
-      summary: Update an enquiry
-      operationId: updateGeneralEnquiry
+    patch:
+      summary: Partially update an enquiry
+      operationId: patchGeneralEnquiry
       tags:
         - General Enquiry
       parameters:
@@ -1547,7 +1547,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DB-Enquiry'
+              $ref: '#/components/schemas/Request-EnquiryPatch'
       responses:
         '200':
           description: Enquiry updated successfully
@@ -1911,9 +1911,9 @@ paths:
           $ref: "#/components/responses/UnprocessableEntity"
         default:
           $ref: '#/components/responses/Error'
-    put:
-      summary: Update a general project
-      operationId: updateGeneralProject
+    patch:
+      summary: Partially update a general project
+      operationId: patchGeneralProject
       tags:
         - General Project
       parameters:
@@ -1923,7 +1923,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Request-GeneralProjectUpdate'
+              $ref: '#/components/schemas/Request-GeneralProjectPatch'
       responses:
         '200':
           description: General Project updated successfully
@@ -2430,9 +2430,9 @@ paths:
           $ref: '#/components/responses/NotFound'
         default:
           $ref: '#/components/responses/Error'
-    put:
-      summary: Update an enquiry
-      operationId: updateHousingEnquiry
+    patch:
+      summary: Partially update an enquiry
+      operationId: patchHousingEnquiry
       tags:
         - Housing Enquiry
       parameters:
@@ -2442,7 +2442,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DB-Enquiry'
+              $ref: '#/components/schemas/Request-EnquiryPatch'
       responses:
         '200':
           description: Enquiry updated successfully
@@ -2894,9 +2894,9 @@ paths:
           $ref: "#/components/responses/UnprocessableEntity"
         default:
           $ref: '#/components/responses/Error'
-    put:
-      summary: Update a housing project
-      operationId: updateHousingProject
+    patch:
+      summary: Partially update a housing project
+      operationId: patchHousingProject
       tags:
         - Housing Project
       parameters:
@@ -2906,7 +2906,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Request-HousingProjectUpdate'
+              $ref: '#/components/schemas/Request-HousingProjectPatch'
       responses:
         '200':
           description: Housing Project updated successfully
@@ -4541,6 +4541,57 @@ components:
             $ref: '#/components/schemas/DB-Contact'
         basic:
           $ref: '#/components/schemas/Enquiry-Basic'
+    Request-EnquiryPatch:
+      title: Request to Partially Update an Enquiry
+      description: >-
+        All properties are optional; only the fields present in the request body are updated.
+        enquiryId is supplied via the path parameter, not the body.
+      type: object
+      properties:
+        submissionType:
+          type: string
+          description: The submission type of the enquiry
+          example: Guidance
+          nullable: true
+        relatedActivityId:
+          type: string
+          description: Activity ID of a related project
+          example: D95F1DE6
+          maxLength: 255
+          nullable: true
+        enquiryDescription:
+          type: string
+          description: Description of the enquiry
+          example: Enquiry description example.
+          nullable: true
+        assignedUserId:
+          type: string
+          description: User ID assigned to the enquiry
+          format: uuid
+          example: 123e4567-e89b-12d3-a456-426614174000
+          nullable: true
+        enquiryStatus:
+          type: string
+          description: Status of the enquiry
+          example: New
+        submittedMethod:
+          type: string
+          description: Method the enquiry was submitted through
+          example: PCNS
+        addedToAts:
+          type: boolean
+          description: Whether added to ATS
+          example: false
+        atsClientId:
+          type: number
+          description: Client number from ATS
+          example: 1001
+          nullable: true
+        atsEnquiryId:
+          type: number
+          description: Enquiry number from ATS
+          example: 1001
+          nullable: true
     Request-Document:
       type: object
       properties:
@@ -4999,53 +5050,122 @@ components:
           type: string
           description: The submission type of the project
           example: Guidance
-    Request-ElectrificationProjectUpdate:
-      title: Request to Update Electrification Project
+    Request-ElectrificationProjectPatch:
+      title: Request to Partially Update Electrification Project
+      description: >-
+        All properties are optional; only the fields present in the request body are updated.
+        electrificationProjectId is supplied via the path parameter, not the body.
       type: object
-      required:
-        - housingProjectId
-        - activityId
-        - submittedAt
       properties:
-        electrificationProjectId:
+        projectName:
           type: string
-          description: UUID for the electrification project
+          description: Name of the Project
+          example: New Project
+          maxLength: 255
+        companyNameRegistered:
+          type: string
+          description: Name of the company connected to the project
+          example: QW URBAN FOOD LTD.
+          maxLength: 255
+          nullable: true
+        companyIdRegistered:
+          type: string
+          description: Registered ID of the company connected to the project
+          example: BC1234567
+          maxLength: 255
+          nullable: true
+        projectType:
+          type: string
+          description: Type of electrification project
+          example: New Connection
+        bcHydroNumber:
+          type: string
+          description: BC Hydro account number
+          example: '1234567890'
+          maxLength: 255
+          nullable: true
+        projectDescription:
+          type: string
+          description: Description of the project. Required when projectType is "Other".
+          example: Project description example.
+          maxLength: 4000
+          nullable: true
+        projectCategory:
+          type: string
+          description: Category of the electrification project
+          example: Generation
+          nullable: true
+        assignedUserId:
+          type: string
+          description: User ID assigned to the electrification project
           format: uuid
-          example: d95f1de6-698b-4d9d-b938-487eb446ace8
-        activityId:
+          example: 123e4567-e89b-12d3-a456-426614174000
+          nullable: true
+        hasEpa:
           type: string
-          description: Activity ID
-          example: D95F1DE6
-        submittedAt:
+          description: Whether the project has an Electricity Purchase Agreement
+          example: 'Yes'
+          nullable: true
+        megawatts:
+          type: number
+          description: Project capacity in megawatts
+          example: 25.5
+          nullable: true
+        bcEnvironmentAssessNeeded:
           type: string
-          description: Date it was submitted
-          format: date-time
-          example: '2024-04-03T00:57:09.070Z'
-    Request-GeneralProjectUpdate:
-      title: Request to Update General Project
+          description: Whether a BC environmental assessment is needed
+          example: 'No'
+          nullable: true
+        locationDescription:
+          type: string
+          description: Description of the location of the project
+          example: Near the river
+          maxLength: 4000
+          nullable: true
+        astNotes:
+          type: string
+          description: Notes from AST
+          example: AST notes here
+          maxLength: 4000
+          nullable: true
+        queuePriority:
+          type: number
+          description: Navigator assigned priority rank
+          format: integer
+          example: 2
+        submissionType:
+          type: string
+          description: The submission type of the project
+          example: Guidance
+        applicationStatus:
+          type: string
+          description: Status of the application
+          example: New
+        addedToAts:
+          type: boolean
+          description: Whether added to ATS
+          example: false
+        atsClientId:
+          type: number
+          description: Client number from ATS
+          example: ATS-001
+          nullable: true
+        atsEnquiryId:
+          type: number
+          description: Enquiry number from ATS
+          example: 1001
+          nullable: true
+        aaiUpdated:
+          type: boolean
+          description: Updated by AAI
+          example: false
+    Request-GeneralProjectPatch:
+      title: Request to Partially Update General Project
+      description: >-
+        All properties are optional; only the fields present in the request body are updated.
+        generalProjectId is supplied via the path parameter, not the body.
       type: object
-      required:
-        - generalProjectId
-        - activityId
-        - queuePriority
-        - submissionType
-        - submittedAt
-        - projectName
-        - naturalDisaster
-        - addedToAts
-        - ltsaCompleted
-        - bcOnlineCompleted
-        - aaiUpdated
       properties:
-        generalProjectId:
-          type: string
-          description: UUID for the general project
-          format: uuid
-          example: d95f1de6-698b-4d9d-b938-487eb446ace8
-        activityId:
-          type: string
-          description: Activity ID
-          example: D95F1DE6
         queuePriority:
           type: number
           description: Navigator assigned priority rank
@@ -5056,19 +5176,22 @@ components:
           type: string
           description: The submission type of the project
           example: Guidance
-        submittedAt:
-          type: string
-          description: Date it was submitted
-          format: date-time
-          example: '2024-04-03T00:57:09.070Z'
         companyNameRegistered:
           type: string
           description: Name of the company connected to the project
           example: QW URBAN FOOD LTD.
+        companyIdRegistered:
+          type: string
+          description: Registered ID of the company connected to the project
+          example: BC1234567
         projectName:
           type: string
           description: Name of the Project
           example: New Project
+        activityType:
+          type: string
+          description: Type of activity
+          example: General
         projectDescription:
           type: string
           description: Description of the project
@@ -5108,31 +5231,23 @@ components:
           example: http://geomark.com
           maxLength: 255
         naturalDisaster:
-          type: string
+          type: boolean
           description: Is it affected by a natural disaster?
-          example: 'No'
+          example: false
         projectLocationDescription:
           type: string
           description: Description of the location of the project
           example: Near the river
           maxLength: 4000
-        addedToAts:
-          type: boolean
-          description: Whether added to ATS
-          example: false
         atsClientId:
           type: number
           description: Client number from ATS
           example: ATS-001
           maxLength: 255
-        ltsaCompleted:
-          type: boolean
-          description: Ltsa completed
-          example: false
-        bcOnlineCompleted:
-          type: boolean
-          description: BC Online completed
-          example: false
+        atsEnquiryId:
+          type: number
+          description: Enquiry number from ATS
+          example: 1001
         aaiUpdated:
           type: boolean
           description: Updated by AAI
@@ -5144,43 +5259,36 @@ components:
           maxLength: 4000
         assignedUserId:
           type: string
-          description: User ID assigned to the housing project
+          description: User ID assigned to the general project
           format: uuid
           example: 123e4567-e89b-12d3-a456-426614174000
         applicationStatus:
           type: string
           description: Status of the application
           example: New
-    Request-HousingProjectUpdate:
-      title: Request to Update Housing Project
+        region:
+          type: string
+          description: Region of the project
+          example: North
+        area:
+          type: string
+          description: Area of the project
+          example: North East
+        businessArea:
+          type: string
+          description: Business area code
+          example: FLNR
+    Request-HousingProjectPatch:
+      title: Request to Partially Update Housing Project
+      description: >-
+        All properties are optional; only the fields present in the request body are updated.
+        housingProjectId is supplied via the path parameter, not the body.
       type: object
-      required:
-        - housingProjectId
-        - activityId
-        - queuePriority
-        - submissionType
-        - submittedAt
-        - projectName
-        - hasRentalUnits
-        - financiallySupportedBc
-        - financiallySupportedIndigenous
-        - financiallySupportedNonProfit
-        - financiallySupportedHousingCoop
-        - naturalDisaster
-        - addedToAts
-        - ltsaCompleted
-        - bcOnlineCompleted
-        - aaiUpdated
       properties:
-        housingProjectId:
-          type: string
-          description: UUID for the housing project
-          format: uuid
-          example: d95f1de6-698b-4d9d-b938-487eb446ace8
-        activityId:
-          type: string
-          description: Activity ID
-          example: D95F1DE6
+        consentToFeedback:
+          type: boolean
+          description: Whether the applicant consented to being contacted for feedback
+          example: false
         queuePriority:
           type: number
           description: Navigator assigned priority rank
@@ -5191,15 +5299,14 @@ components:
           type: string
           description: The submission type of the project
           example: Guidance
-        submittedAt:
-          type: string
-          description: Date it was submitted
-          format: date-time
-          example: '2024-04-03T00:57:09.070Z'
         companyNameRegistered:
           type: string
           description: Name of the company connected to the project
           example: QW URBAN FOOD LTD.
+        companyIdRegistered:
+          type: string
+          description: Registered ID of the company connected to the project
+          example: BC1234567
         projectName:
           type: string
           description: Name of the Project
@@ -5300,9 +5407,9 @@ components:
           example: http://geomark.com
           maxLength: 255
         naturalDisaster:
-          type: string
+          type: boolean
           description: Is it affected by a natural disaster?
-          example: 'No'
+          example: false
         projectLocationDescription:
           type: string
           description: Description of the location of the project
@@ -5317,6 +5424,10 @@ components:
           description: Client number from ATS
           example: ATS-001
           maxLength: 255
+        atsEnquiryId:
+          type: number
+          description: Enquiry number from ATS
+          example: 1001
         ltsaCompleted:
           type: boolean
           description: Ltsa completed

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -106,7 +106,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DB-Contact'
+              $ref: '#/components/schemas/Request-ContactUpsert'
       responses:
         '200':
           description: Contact upserted successfully
@@ -841,7 +841,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DB-Permit'
+              $ref: '#/components/schemas/Request-PermitUpsert'
       responses:
         '200':
           description: Permit upserted successfully
@@ -1841,7 +1841,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DB-Permit'
+              $ref: '#/components/schemas/Request-PermitUpsert'
       responses:
         '200':
           description: Permit upserted successfully
@@ -2757,7 +2757,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DB-Permit'
+              $ref: '#/components/schemas/Request-PermitUpsert'
       responses:
         '200':
           description: Permit upserted successfully
@@ -4715,6 +4715,144 @@ components:
           description: Enquiry number from ATS
           example: 1001
           nullable: true
+    Request-PermitUpsert:
+      title: Request Permit Upsert
+      type: object
+      required:
+        - permitTypeId
+        - needed
+        - state
+        - stage
+      properties:
+        permitId:
+          type: string
+          format: uuid
+          nullable: true
+          description: UUID for permit. Omit to create a new permit.
+          example: 68a9a188-4d67-46e3-92a4-b57174354231
+        activityId:
+          type: string
+          description: The ID of the activity associated with the permit
+          example: 2DE67F13
+        permitTypeId:
+          type: number
+          description: ID for the associated permit type
+          example: 1
+        issuedPermitId:
+          type: string
+          nullable: true
+          description: ID of the issued permit
+          example: '123'
+        needed:
+          type: string
+          description: Whether permit is needed, or still uner investigation
+          example: 'Yes'
+        state:
+          type: string
+          description: State of the permit
+          example: In progress
+        stage:
+          type: string
+          description: Stage of the permit
+          example: Application submission
+        submittedDate:
+          type: string
+          description: Date the permit was submitted
+          format: date
+          nullable: true
+          example: '2024-08-14'
+        submittedTime:
+          type: string
+          description: Time the permit was submitted
+          format: timetz
+          nullable: true
+          example: '07:00:00.000Z'
+        decisionDate:
+          type: string
+          description: Date of the permit's decision
+          format: date
+          nullable: true
+          example: '2024-08-14'
+        decisionTime:
+          type: string
+          description: Time of the permit's decision
+          format: timetz
+          nullable: true
+          example: '2024-08-14'
+        statusLastChanged:
+          type: string
+          description: Date of the last time the status of permit was changed
+          format: date
+          nullable: true
+          example: '2024-08-14'
+        statusLastChangedTime:
+          type: string
+          description: Time of the last time the status of permit was changed
+          format: timetz
+          nullable: true
+          example: '07:00:00.000Z'
+        statusLastVerified:
+          type: string
+          description: Date of the last verified status of permit
+          format: date
+          nullable: true
+          example: '2024-08-14'
+        statusLastVerifiedTime:
+          type: string
+          description: Time of the last verified status of permit
+          format: timetz
+          nullable: true
+          example: '07:00:00.000Z'
+    Request-ContactUpsert:
+      title: Request Contact Upsert
+      type: object
+      required:
+        - email
+        - firstName
+        - phoneNumber
+        - contactApplicantRelationship
+        - contactPreference
+      properties:
+        userId:
+          type: string
+          format: uuid
+          nullable: true
+          description: The ID of the user associated with the contact
+          example: b76469a3-896c-4435-aa83-b8b87db6f701
+        contactId:
+          type: string
+          format: uuid
+          nullable: true
+          description: The ID of the contact. Omit to create a new contact.
+          example: b76469a3-896c-4435-aa83-b8b87db6f701
+        firstName:
+          type: string
+          description: First name of the contact person
+          example: John
+        lastName:
+          type: string
+          nullable: true
+          description: Last name of the contact person
+          example: Smith
+        phoneNumber:
+          type: string
+          description: Phone number for contact
+          example: (123) 456-7890
+        email:
+          type: string
+          format: email
+          description: Email address for contact
+          example: john.smith@example.com
+        contactApplicantRelationship:
+          type: string
+          enum: [Property owner, Project consultant, Other]
+          description: Relationship of the contact person to the project
+          example: Agent
+        contactPreference:
+          type: string
+          enum: [Phone call, Email, Either]
+          description: Preferred method of contact
+          example: Email
     Request-Document:
       type: object
       properties:
@@ -4797,10 +4935,6 @@ components:
       required:
         - resource
       properties:
-        activityId:
-          type: string
-          description: The ID of the activity the note is associated with
-          example: 2DE67F13
         type:
           type: string
           description: Type of note

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -96,6 +96,32 @@ paths:
           $ref: "#/components/responses/UnprocessableEntity"
         default:
           $ref: '#/components/responses/Error'
+    post:
+      summary: Create or update a contact
+      operationId: upsertContact
+      tags:
+        - Contact
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DB-Contact'
+      responses:
+        '200':
+          description: Contact upserted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DB-Contact'
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+        default:
+          $ref: '#/components/responses/Error'
   /contact/{contactId}:
     get:
       summary: Get a specific contact
@@ -688,9 +714,9 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /electrification/note/{noteHistoryId}:
-    put:
-      summary: Update a note history
-      operationId: updateElectrificationNoteHistory
+    patch:
+      summary: Partially update a note history
+      operationId: patchElectrificationNoteHistory
       tags:
         - Electrification Note
       parameters:
@@ -700,7 +726,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Request-NoteHistory'
+              $ref: '#/components/schemas/Request-NoteHistoryPatch'
       responses:
         '200':
           description: Note history updated successfully
@@ -816,6 +842,32 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Response-Permit'
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Create or update a permit
+      operationId: upsertElectrificationPermit
+      tags:
+        - Electrification Permit
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DB-Permit'
+      responses:
+        '200':
+          description: Permit upserted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response-Permit'
         "401":
           $ref: "#/components/responses/Unauthorized"
         '403':
@@ -1075,7 +1127,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /electrification/project/draft:
-    put:
+    post:
       summary: Create or update a draft electrification project
       description: >-
         Creates or updates an intake and set status to Draft
@@ -1103,7 +1155,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /electrification/project/draft/submit:
-    put:
+    post:
       summary: Submit a draft electrification project
       description: Creates or updates an intake and set status to Submitted
       operationId: electrificationProject-updateDraft
@@ -1257,7 +1309,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /electrification/roadmap:
-    put:
+    post:
       summary: Send an email with the roadmap data
       operationId: electrificationRoadmap
       tags:
@@ -1664,9 +1716,9 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /general/note/{noteHistoryId}:
-    put:
-      summary: Update a note history
-      operationId: updateGeneralNoteHistory
+    patch:
+      summary: Partially update a note history
+      operationId: patchGeneralNoteHistory
       tags:
         - General Note
       parameters:
@@ -1676,7 +1728,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Request-NoteHistory'
+              $ref: '#/components/schemas/Request-NoteHistoryPatch'
       responses:
         '200':
           description: Note history updated successfully
@@ -1792,6 +1844,32 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Response-Permit'
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Create or update a permit
+      operationId: upsertGeneralPermit
+      tags:
+        - General Permit
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DB-Permit'
+      responses:
+        '200':
+          description: Permit upserted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response-Permit'
         "401":
           $ref: "#/components/responses/Unauthorized"
         '403':
@@ -1962,7 +2040,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /general/project/draft:
-    put:
+    post:
       summary: Create or update a draft general project
       description: >-
         Creates or updates an intake and set status to Draft
@@ -1990,7 +2068,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /general/project/draft/submit:
-    put:
+    post:
       summary: Submit a draft general project
       description: Creates or updates an intake and set status to Submitted
       operationId: generalProject-updateDraft
@@ -2152,7 +2230,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /general/roadmap:
-    put:
+    post:
       summary: Send an email with the roadmap data
       operationId: generalRoadmap
       tags:
@@ -2559,9 +2637,9 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /housing/note/{noteHistoryId}:
-    put:
-      summary: Update a note history
-      operationId: updateHousingNoteHistory
+    patch:
+      summary: Partially update a note history
+      operationId: patchHousingNoteHistory
       tags:
         - Housing Note
       parameters:
@@ -2571,7 +2649,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Request-NoteHistory'
+              $ref: '#/components/schemas/Request-NoteHistoryPatch'
       responses:
         '200':
           description: Note history updated successfully
@@ -2687,6 +2765,32 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Response-Permit'
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+        default:
+          $ref: '#/components/responses/Error'
+    post:
+      summary: Create or update a permit
+      operationId: upsertHousingPermit
+      tags:
+        - Housing Permit
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DB-Permit'
+      responses:
+        '200':
+          description: Permit upserted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response-Permit'
         "401":
           $ref: "#/components/responses/Unauthorized"
         '403':
@@ -2945,7 +3049,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /housing/project/draft:
-    put:
+    post:
       summary: Create or update a draft housing project
       description: >-
         Creates or updates an intake and set status to Draft
@@ -2973,7 +3077,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /housing/project/draft/submit:
-    put:
+    post:
       summary: Submit a draft housing project
       description: Creates or updates an intake and set status to Submitted
       operationId: housingProject-updateDraft
@@ -3135,7 +3239,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /housing/roadmap:
-    put:
+    post:
       summary: Send an email with the roadmap data
       operationId: housingRoadmap
       tags:
@@ -4668,6 +4772,65 @@ components:
           type: string
           description: A reason for the escalation
           example: Time-sensitive
+    Request-NoteHistoryPatch:
+      title: Request Note History Patch
+      type: object
+      required:
+        - resource
+      properties:
+        activityId:
+          type: string
+          description: The ID of the activity the note is associated with
+          example: 2DE67F13
+        type:
+          type: string
+          description: Type of note
+          example: Bring forward
+        title:
+          type: string
+          description: Title of the note
+          example: Some Title
+        bringForwardDate:
+          type: string
+          format: date-time
+          nullable: true
+          description: Date time for when note is to be brought forward
+          example: '2029-08-14T07:00:00.000Z'
+        bringForwardState:
+          type: string
+          nullable: true
+          description: State of a bring forward type note
+          example: Unresolved
+        note:
+          type: string
+          nullable: true
+          description: Optional note to add to the history
+          example: Some new note text
+        shownToProponent:
+          type: boolean
+          description: If the note history is displayed to the proponent
+          example: false
+        escalateToSupervisor:
+          type: boolean
+          description: If the note history is to be escalated to a supervisor
+          example: false
+        escalateToDirector:
+          type: boolean
+          description: If the note history is to be escalated to a director
+          example: false
+        escalationType:
+          type: string
+          nullable: true
+          description: A reason for the escalation
+          example: Time-sensitive
+        resource:
+          type: string
+          description: The type of Resource the note history belongs to
+          enum:
+            - ELECTRIFICATION_PROJECT
+            - ENQUIRY
+            - GENERAL_PROJECT
+            - HOUSING_PROJECT
     Request-PermitNote:
       title: Request Permit Note
       type: object

--- a/app/src/repositories/electrificationProject.ts
+++ b/app/src/repositories/electrificationProject.ts
@@ -1,7 +1,7 @@
 import { WritableRepository } from './writable.ts';
 
 import type { PrismaTransactionClient } from '../db/database.ts';
-import type { ElectrificationProject, ElectrificationProjectSearchParameters } from '../types/index.ts';
+import type { ElectrificationProject, SearchElectrificationProjectRequest } from '../types/index.ts';
 
 export class ElectrificationProjectRepository extends WritableRepository<
   PrismaTransactionClient['electrification_project']
@@ -10,7 +10,7 @@ export class ElectrificationProjectRepository extends WritableRepository<
     super(tx.electrification_project, principal, true);
   }
 
-  public async search(params: ElectrificationProjectSearchParameters): Promise<ElectrificationProject[]> {
+  public async search(params: SearchElectrificationProjectRequest): Promise<ElectrificationProject[]> {
     return await this.findMany({
       where: {
         AND: [

--- a/app/src/repositories/enquiry.ts
+++ b/app/src/repositories/enquiry.ts
@@ -2,14 +2,14 @@ import { WritableRepository } from './writable.ts';
 import { Initiative } from '../utils/enums/application.ts';
 
 import type { PrismaTransactionClient } from '../db/database.ts';
-import type { EnquirySearchParameters } from '../types/index.ts';
+import type { SearchEnquiriesRequest } from '../types/index.ts';
 
 export class EnquiryRepository extends WritableRepository<PrismaTransactionClient['enquiry']> {
   constructor(tx: PrismaTransactionClient, principal: string) {
     super(tx.enquiry, principal, true);
   }
 
-  public async search(params: EnquirySearchParameters, initiativeCode?: Initiative) {
+  public async search(params: SearchEnquiriesRequest, initiativeCode?: Initiative) {
     return await this.findMany({
       where: {
         AND: [

--- a/app/src/repositories/generalProject.ts
+++ b/app/src/repositories/generalProject.ts
@@ -1,11 +1,25 @@
+import { jsonToPrismaInputJson } from '../db/utils/utils.ts';
 import { WritableRepository } from './writable.ts';
 
+import type { Prisma } from '@prisma/client';
 import type { PrismaTransactionClient } from '../db/database.ts';
-import type { GeneralProject, GeneralProjectSearchParameters } from '../types/index.ts';
+import type { GeneralProject, GeneralProjectSearchParameters, PatchGeneralProjectRequest } from '../types/index.ts';
 
 export class GeneralProjectRepository extends WritableRepository<PrismaTransactionClient['general_project']> {
   constructor(tx: PrismaTransactionClient, principal: string) {
     super(tx.general_project, principal, true);
+  }
+
+  public async patch(where: { generalProjectId: string }, data: PatchGeneralProjectRequest) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { generalProjectId: _id, geoJson, ...rest } = data;
+
+    const updateData: Prisma.general_projectUncheckedUpdateInput = {
+      ...rest,
+      ...(geoJson !== undefined && { geoJson: jsonToPrismaInputJson(geoJson) })
+    };
+
+    return this.update(where, updateData);
   }
 
   public async search(params: GeneralProjectSearchParameters): Promise<GeneralProject[]> {

--- a/app/src/repositories/generalProject.ts
+++ b/app/src/repositories/generalProject.ts
@@ -3,7 +3,7 @@ import { WritableRepository } from './writable.ts';
 
 import type { Prisma } from '@prisma/client';
 import type { PrismaTransactionClient } from '../db/database.ts';
-import type { GeneralProject, GeneralProjectSearchParameters, PatchGeneralProjectRequest } from '../types/index.ts';
+import type { GeneralProject, PatchGeneralProjectRequest, SearchGeneralProjectRequest } from '../types/index.ts';
 
 export class GeneralProjectRepository extends WritableRepository<PrismaTransactionClient['general_project']> {
   constructor(tx: PrismaTransactionClient, principal: string) {
@@ -11,8 +11,7 @@ export class GeneralProjectRepository extends WritableRepository<PrismaTransacti
   }
 
   public async patch(where: { generalProjectId: string }, data: PatchGeneralProjectRequest) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { generalProjectId: _id, geoJson, ...rest } = data;
+    const { geoJson, ...rest } = data;
 
     const updateData: Prisma.general_projectUncheckedUpdateInput = {
       ...rest,
@@ -22,7 +21,7 @@ export class GeneralProjectRepository extends WritableRepository<PrismaTransacti
     return this.update(where, updateData);
   }
 
-  public async search(params: GeneralProjectSearchParameters): Promise<GeneralProject[]> {
+  public async search(params: SearchGeneralProjectRequest): Promise<GeneralProject[]> {
     return await this.findMany({
       where: {
         AND: [

--- a/app/src/repositories/housingProject.ts
+++ b/app/src/repositories/housingProject.ts
@@ -1,11 +1,25 @@
 import { WritableRepository } from './writable.ts';
+import { jsonToPrismaInputJson } from '../db/utils/utils.ts';
 
+import type { Prisma } from '@prisma/client';
 import type { PrismaTransactionClient } from '../db/database.ts';
-import type { HousingProject, HousingProjectSearchParameters } from '../types/index.ts';
+import type { HousingProject, HousingProjectSearchParameters, PatchHousingProjectRequest } from '../types/index.ts';
 
 export class HousingProjectRepository extends WritableRepository<PrismaTransactionClient['housing_project']> {
   constructor(tx: PrismaTransactionClient, principal: string) {
     super(tx.housing_project, principal, true);
+  }
+
+  public async patch(where: { housingProjectId: string }, data: PatchHousingProjectRequest) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { housingProjectId: _id, geoJson, ...rest } = data;
+
+    const updateData: Prisma.housing_projectUncheckedUpdateInput = {
+      ...rest,
+      ...(geoJson !== undefined && { geoJson: jsonToPrismaInputJson(geoJson) })
+    };
+
+    return this.update(where, updateData);
   }
 
   public async search(params: HousingProjectSearchParameters): Promise<HousingProject[]> {

--- a/app/src/repositories/housingProject.ts
+++ b/app/src/repositories/housingProject.ts
@@ -3,7 +3,7 @@ import { jsonToPrismaInputJson } from '../db/utils/utils.ts';
 
 import type { Prisma } from '@prisma/client';
 import type { PrismaTransactionClient } from '../db/database.ts';
-import type { HousingProject, HousingProjectSearchParameters, PatchHousingProjectRequest } from '../types/index.ts';
+import type { HousingProject, SearchHousingProjectRequest, PatchHousingProjectRequest } from '../types/index.ts';
 
 export class HousingProjectRepository extends WritableRepository<PrismaTransactionClient['housing_project']> {
   constructor(tx: PrismaTransactionClient, principal: string) {
@@ -11,8 +11,7 @@ export class HousingProjectRepository extends WritableRepository<PrismaTransacti
   }
 
   public async patch(where: { housingProjectId: string }, data: PatchHousingProjectRequest) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { housingProjectId: _id, geoJson, ...rest } = data;
+    const { geoJson, ...rest } = data;
 
     const updateData: Prisma.housing_projectUncheckedUpdateInput = {
       ...rest,
@@ -22,7 +21,7 @@ export class HousingProjectRepository extends WritableRepository<PrismaTransacti
     return this.update(where, updateData);
   }
 
-  public async search(params: HousingProjectSearchParameters): Promise<HousingProject[]> {
+  public async search(params: SearchHousingProjectRequest): Promise<HousingProject[]> {
     return await this.findMany({
       where: {
         AND: [

--- a/app/src/routes/v1/contact.ts
+++ b/app/src/routes/v1/contact.ts
@@ -48,7 +48,7 @@ router.get(
 );
 
 /** Create or update a contact */
-router.put(
+router.post(
   '/',
   hasAuthorization(Resource.CONTACT, Action.UPDATE),
   contactValidator.upsertContact,

--- a/app/src/routes/v1/electrificationProject.ts
+++ b/app/src/routes/v1/electrificationProject.ts
@@ -10,9 +10,9 @@ import {
   getElectrificationProjectStatisticsController,
   listElectrificationProjectActivityIdsController,
   listElectrificationProjectsController,
+  patchElectrificationProjectController,
   searchElectrificationProjectsController,
   submitElectrificationProjectDraftController,
-  updateElectrificationProjectController,
   upsertElectrificationProjectDraftController
 } from '../../controllers/electrificationProject.ts';
 import { hasAccess, hasAuthorization } from '../../middleware/authorization.ts';
@@ -62,14 +62,14 @@ router.get(
 );
 
 /** Creates or updates an intake and set status to Draft */
-router.put(
+router.post(
   '/draft',
   hasAuthorization(Resource.ELECTRIFICATION_PROJECT, Action.CREATE),
   upsertElectrificationProjectDraftController
 );
 
 /** Creates or updates an intake and set status to Submitted */
-router.put(
+router.post(
   '/draft/submit',
   hasAuthorization(Resource.ELECTRIFICATION_PROJECT, Action.CREATE),
   electrificationProjectValidator.createElectrificationProject,
@@ -102,13 +102,13 @@ router.get(
   getElectrificationProjectController
 );
 
-/** Updates a electrification project*/
+/** Patches a electrification project*/
 router.patch(
   '/:electrificationProjectId',
   hasAuthorization(Resource.ELECTRIFICATION_PROJECT, Action.UPDATE),
   hasAccess('electrificationProjectId'),
-  electrificationProjectValidator.updateElectrificationProject,
-  updateElectrificationProjectController
+  electrificationProjectValidator.patchElectrificationProject,
+  patchElectrificationProjectController
 );
 
 /** Deletes an electrification project */

--- a/app/src/routes/v1/enquiry.ts
+++ b/app/src/routes/v1/enquiry.ts
@@ -6,8 +6,8 @@ import {
   getEnquiryController,
   listEnquiriesController,
   listRelatedEnquiriesController,
-  searchEnquiriesController,
-  updateEnquiryController
+  patchEnquiryController,
+  searchEnquiriesController
 } from '../../controllers/enquiry.ts';
 import { hasAccess, hasAuthorization } from '../../middleware/authorization.ts';
 import { requireSomeAuth } from '../../middleware/requireSomeAuth.ts';
@@ -54,13 +54,13 @@ router.post(
   createEnquiryController
 );
 
-/** Updates an enquiry */
+/** Patches an enquiry */
 router.patch(
   '/:enquiryId',
   hasAuthorization(Resource.ENQUIRY, Action.UPDATE),
   hasAccess('enquiryId'),
-  enquiryValidator.updateEnquiry,
-  updateEnquiryController
+  enquiryValidator.patchEnquiry,
+  patchEnquiryController
 );
 
 /** Deletes an enquiry */

--- a/app/src/routes/v1/generalProject.ts
+++ b/app/src/routes/v1/generalProject.ts
@@ -10,9 +10,9 @@ import {
   getGeneralProjectStatisticsController,
   listGeneralProjectActivityIdsController,
   listGeneralProjectsController,
+  patchGeneralProjectController,
   searchGeneralProjectsController,
   submitGeneralProjectDraftController,
-  updateGeneralProjectController,
   upsertGeneralProjectDraftController
 } from '../../controllers/generalProject.ts';
 import { hasAccess, hasAuthorization } from '../../middleware/authorization.ts';
@@ -63,10 +63,10 @@ router.get(
 router.get('/draft', hasAuthorization(Resource.GENERAL_PROJECT, Action.READ), getGeneralProjectDraftsController);
 
 /** Creates or updates an intake and set status to Draft */
-router.put('/draft', hasAuthorization(Resource.GENERAL_PROJECT, Action.CREATE), upsertGeneralProjectDraftController);
+router.post('/draft', hasAuthorization(Resource.GENERAL_PROJECT, Action.CREATE), upsertGeneralProjectDraftController);
 
 /** Creates or updates an intake and set status to Submitted */
-router.put(
+router.post(
   '/draft/submit',
   hasAuthorization(Resource.GENERAL_PROJECT, Action.CREATE),
   generalProjectValidator.createGeneralProject,
@@ -99,13 +99,13 @@ router.get(
   getGeneralProjectController
 );
 
-/** Updates a general project*/
+/** Patches a general project*/
 router.patch(
   '/:generalProjectId',
   hasAuthorization(Resource.GENERAL_PROJECT, Action.UPDATE),
   hasAccess('generalProjectId'),
-  generalProjectValidator.updateGeneralProject,
-  updateGeneralProjectController
+  generalProjectValidator.patchGeneralProject,
+  patchGeneralProjectController
 );
 
 /** Deletes a general project */

--- a/app/src/routes/v1/housingProject.ts
+++ b/app/src/routes/v1/housingProject.ts
@@ -10,9 +10,9 @@ import {
   getHousingProjectStatisticsController,
   listHousingProjectActivityIdsController,
   listHousingProjectsController,
+  patchHousingProjectController,
   searchHousingProjectsController,
   submitHousingProjectDraftController,
-  updateHousingProjectController,
   upsertHousingProjectDraftController
 } from '../../controllers/housingProject.ts';
 import { hasAccess, hasAuthorization } from '../../middleware/authorization.ts';
@@ -64,10 +64,10 @@ router.get(
 router.get('/draft', hasAuthorization(Resource.HOUSING_PROJECT, Action.READ), getHousingProjectDraftsController);
 
 /** Creates or updates an intake and set status to Draft */
-router.put('/draft', hasAuthorization(Resource.HOUSING_PROJECT, Action.CREATE), upsertHousingProjectDraftController);
+router.post('/draft', hasAuthorization(Resource.HOUSING_PROJECT, Action.CREATE), upsertHousingProjectDraftController);
 
 /** Creates or updates an intake and set status to Submitted */
-router.put(
+router.post(
   '/draft/submit',
   hasAuthorization(Resource.HOUSING_PROJECT, Action.CREATE),
   housingProjectValidator.createHousingProject,
@@ -101,13 +101,13 @@ router.get(
   getHousingProjectController
 );
 
-/** Updates a housing project*/
+/** Patches a housing project*/
 router.patch(
   '/:housingProjectId',
   hasAuthorization(Resource.HOUSING_PROJECT, Action.UPDATE),
   hasAccess('housingProjectId'),
-  housingProjectValidator.updateHousingProject,
-  updateHousingProjectController
+  housingProjectValidator.patchHousingProject,
+  patchHousingProjectController
 );
 
 /** Deletes a housing project */

--- a/app/src/routes/v1/noteHistory.ts
+++ b/app/src/routes/v1/noteHistory.ts
@@ -5,7 +5,7 @@ import {
   deleteNoteHistoryController,
   listBringForwardsController,
   listNoteHistoriesController,
-  updateNoteHistoryController
+  patchNoteHistoryController
 } from '../../controllers/noteHistory.ts';
 import { hasAccess, hasAuthorization } from '../../middleware/authorization.ts';
 import { requireSomeAuth } from '../../middleware/requireSomeAuth.ts';
@@ -25,13 +25,13 @@ router.post(
   createNoteHistoryController
 );
 
-/** Update a note history */
-router.put(
+/** Patch a note history */
+router.patch(
   '/:noteHistoryId',
   hasAuthorization(Resource.NOTE, Action.UPDATE),
   hasAccess('noteHistoryId'),
-  noteHistoryValidator.updateNoteHistory,
-  updateNoteHistoryController
+  noteHistoryValidator.patchNoteHistory,
+  patchNoteHistoryController
 );
 
 /** Delete a note history */

--- a/app/src/routes/v1/permit.ts
+++ b/app/src/routes/v1/permit.ts
@@ -22,7 +22,12 @@ router.use(requireSomeGroup);
 router.get('/', hasAuthorization(Resource.PERMIT, Action.READ), permitValidator.listPermits, listPermitsController);
 
 /** Create or update a permit */
-router.put('/', hasAuthorization(Resource.PERMIT, Action.CREATE), permitValidator.upsertPermit, upsertPermitController);
+router.post(
+  '/',
+  hasAuthorization(Resource.PERMIT, Action.CREATE),
+  permitValidator.upsertPermit,
+  upsertPermitController
+);
 
 /** Delete a permit */
 router.delete(

--- a/app/src/routes/v1/roadmap.ts
+++ b/app/src/routes/v1/roadmap.ts
@@ -14,7 +14,7 @@ router.use(hasIdentity(IdentityProviderKind.AZUREIDIR));
 router.use(requireSomeGroup);
 
 /** Send an email with the roadmap data */
-router.put('/', hasAuthorization(Resource.ROADMAP, Action.CREATE), roadmapValidator.send, sendRoadmapController);
+router.post('/', hasAuthorization(Resource.ROADMAP, Action.CREATE), roadmapValidator.send, sendRoadmapController);
 
 /** Get the roadmap note for a project */
 router.get('/note', hasAuthorization(Resource.ROADMAP, Action.READ), getRoadmapNoteController);

--- a/app/src/routes/v1/user.ts
+++ b/app/src/routes/v1/user.ts
@@ -14,6 +14,6 @@ router.use(hasIdentity(IdentityProviderKind.AZUREIDIR));
 router.use(requireSomeGroup);
 
 /** Search users endpoint */
-router.post('/', hasAuthorization(Resource.USER, Action.READ), userValidator.searchUsers, searchUsersController);
+router.post('/search', hasAuthorization(Resource.USER, Action.READ), userValidator.searchUsers, searchUsersController);
 
 export default router;

--- a/app/src/services/electrificationProject.ts
+++ b/app/src/services/electrificationProject.ts
@@ -6,7 +6,6 @@ import { filterActivityResponseByScope } from '../parsers/responseFiltering.ts';
 import { Initiative } from '../utils/enums/application.ts';
 import { confirmationTemplateElectrificationSubmission } from '../utils/templates.ts';
 
-import type { Prisma } from '@prisma/client';
 import type {
   ContactBase,
   CurrentAuthorization,
@@ -15,7 +14,8 @@ import type {
   ElectrificationProjectIntake,
   ElectrificationProjectSearchParameters,
   ElectrificationProjectStatistics,
-  Maybe
+  Maybe,
+  PatchElectrificationProjectRequest
 } from '../types/index.ts';
 
 export const createElectrificationProjectService = async (
@@ -212,20 +212,23 @@ export const submitElectrificationProjectDraftService = async (
 
 /**
  * Updates a specific electrification project
- * @param data Electrification project to update
  * @param electrificationProjectId ID of the project to update
+ * @param data Electrification project to update
  * @returns A Promise that resolves to the updated electrification project
  */
-export const updateElectrificationProjectService = async (
-  data: Omit<Prisma.electrification_projectUpdateInput, 'electrificationProjectId'>,
-  electrificationProjectId: string
+export const patchElectrificationProjectService = async (
+  electrificationProjectId: string,
+  data: PatchElectrificationProjectRequest
 ): Promise<ElectrificationProject> => {
   return await unitOfWork.execute(async ({ electrificationProject }) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { electrificationProjectId: _id, ...rest } = data;
+
     await electrificationProject.update(
       {
         electrificationProjectId
       },
-      data
+      rest
     );
 
     return await electrificationProject.findFirstOrThrow({

--- a/app/src/services/electrificationProject.ts
+++ b/app/src/services/electrificationProject.ts
@@ -12,10 +12,10 @@ import type {
   CurrentContext,
   ElectrificationProject,
   ElectrificationProjectIntake,
-  ElectrificationProjectSearchParameters,
   ElectrificationProjectStatistics,
   Maybe,
-  PatchElectrificationProjectRequest
+  PatchElectrificationProjectRequest,
+  SearchElectrificationProjectRequest
 } from '../types/index.ts';
 
 export const createElectrificationProjectService = async (
@@ -160,7 +160,7 @@ export const listElectrificationProjectsService = async (
 export const searchElectrificationProjects = async (
   currentAuthorization: CurrentAuthorization,
   currentContext: CurrentContext,
-  params: ElectrificationProjectSearchParameters
+  params: SearchElectrificationProjectRequest
 ): Promise<ElectrificationProject[]> => {
   return await unitOfWork.execute(async ({ activityContact, contact, electrificationProject }) => {
     const result = await electrificationProject.search(params);
@@ -221,14 +221,11 @@ export const patchElectrificationProjectService = async (
   data: PatchElectrificationProjectRequest
 ): Promise<ElectrificationProject> => {
   return await unitOfWork.execute(async ({ electrificationProject }) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { electrificationProjectId: _id, ...rest } = data;
-
     await electrificationProject.update(
       {
         electrificationProjectId
       },
-      rest
+      data
     );
 
     return await electrificationProject.findFirstOrThrow({

--- a/app/src/services/enquiry.ts
+++ b/app/src/services/enquiry.ts
@@ -3,13 +3,13 @@ import { emailEnquiryConfirmation, generateEnquiryData } from '../domains/enquir
 import { filterActivityResponseByScope } from '../parsers/responseFiltering.ts';
 import { ActivityContactRole, EnquirySubmittedMethod } from '../utils/enums/projectCommon.ts';
 
-import type { Prisma } from '@prisma/client';
 import type {
   CurrentAuthorization,
   CurrentContext,
   Enquiry,
   EnquiryIntake,
-  EnquirySearchParameters
+  EnquirySearchParameters,
+  PatchEnquiryRequest
 } from '../types/index.ts';
 import type { Initiative } from '../utils/enums/application.ts';
 
@@ -232,16 +232,15 @@ export const searchEnquiriesService = async (
 
 /**
  * Updates a specific enquiry
- * @param data Enquiry to update
  * @param enquiryId ID of the enquiry to update
+ * @param data Enquiry to update
  * @returns A Promise that resolves to the updated enquiry
  */
-export const updateEnquiryService = async (
-  data: Omit<Prisma.enquiryUpdateInput, 'enquiryId'>,
-  enquiryId: string
-): Promise<Enquiry> => {
+export const patchEnquiryService = async (enquiryId: string, data: PatchEnquiryRequest): Promise<Enquiry> => {
   return await unitOfWork.execute(async ({ enquiry }) => {
-    await enquiry.update({ enquiryId }, data);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { enquiryId: _id, ...rest } = data;
+    await enquiry.update({ enquiryId }, rest);
     return await enquiry.findFirstOrThrow({
       where: { enquiryId },
       include: { activity: { include: { activityContact: { include: { contact: true } } } } }

--- a/app/src/services/enquiry.ts
+++ b/app/src/services/enquiry.ts
@@ -4,12 +4,13 @@ import { filterActivityResponseByScope } from '../parsers/responseFiltering.ts';
 import { ActivityContactRole, EnquirySubmittedMethod } from '../utils/enums/projectCommon.ts';
 
 import type {
+  CreateEnquiryResponse,
   CurrentAuthorization,
   CurrentContext,
   Enquiry,
   EnquiryIntake,
-  EnquirySearchParameters,
-  PatchEnquiryRequest
+  PatchEnquiryRequest,
+  SearchEnquiriesRequest
 } from '../types/index.ts';
 import type { Initiative } from '../utils/enums/application.ts';
 
@@ -22,7 +23,7 @@ import type { Initiative } from '../utils/enums/application.ts';
 export const createEnquiryService = async (
   currentContext: CurrentContext,
   intakeData: EnquiryIntake
-): Promise<Enquiry> => {
+): Promise<CreateEnquiryResponse> => {
   return await unitOfWork.execute(
     async ({
       activity,
@@ -204,18 +205,14 @@ export const listRelatedEnquiriesService = async (
  * Search and filter for specific enquiries
  * @param currentAuthorization - Authorizations assigned to the current authorized user
  * @param currentContext - Context data of current request
- * @param params Optional filtering parameters
- * @param params.activityId Optional array of uuids representing the activity ID
- * @param params.createdBy Optional array of uuids representing users who created enquiries
- * @param params.enquiryId Optional array of uuids representing the enquiry ID
- * @param params.includeUser Optional boolean representing whether the linked user should be included
- * @param initiative Initiative to search in
+ * @param params - Optional filtering parameters
+ * @param initiative - Initiative to search in
  * @returns A Promise that resolves to an array of enquiries from search params
  */
 export const searchEnquiriesService = async (
   currentAuthorization: CurrentAuthorization,
   currentContext: CurrentContext,
-  params: EnquirySearchParameters,
+  params: SearchEnquiriesRequest,
   initiative: Initiative
 ): Promise<Enquiry[]> => {
   return await unitOfWork.execute(async ({ activityContact, contact, enquiry }) => {
@@ -238,9 +235,7 @@ export const searchEnquiriesService = async (
  */
 export const patchEnquiryService = async (enquiryId: string, data: PatchEnquiryRequest): Promise<Enquiry> => {
   return await unitOfWork.execute(async ({ enquiry }) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { enquiryId: _id, ...rest } = data;
-    await enquiry.update({ enquiryId }, rest);
+    await enquiry.update({ enquiryId }, data);
     return await enquiry.findFirstOrThrow({
       where: { enquiryId },
       include: { activity: { include: { activityContact: { include: { contact: true } } } } }

--- a/app/src/services/generalProject.ts
+++ b/app/src/services/generalProject.ts
@@ -16,7 +16,8 @@ import type {
   GeneralProjectIntake,
   GeneralProjectSearchParameters,
   GeneralProjectStatistics,
-  Maybe
+  Maybe,
+  PatchGeneralProjectRequest
 } from '../types/index.ts';
 
 export const createGeneralProjectService = async (
@@ -209,21 +210,16 @@ export const submitGeneralProjectDraftService = async (
 
 /**
  * Updates a specific general project
- * @param data General project to update
  * @param generalProjectId ID of the project to update
+ * @param data General project to update
  * @returns A Promise that resolves to the updated general project
  */
-export const updateGeneralProjectService = async (
-  data: Omit<Prisma.general_projectUpdateInput, 'generalProjectId'>,
-  generalProjectId: string
+export const patchGeneralProjectService = async (
+  generalProjectId: string,
+  data: PatchGeneralProjectRequest
 ): Promise<GeneralProject> => {
   return await unitOfWork.execute(async ({ generalProject }) => {
-    await generalProject.update(
-      {
-        generalProjectId
-      },
-      data
-    );
+    await generalProject.patch({ generalProjectId }, data);
 
     return await generalProject.findFirstOrThrow({
       where: {

--- a/app/src/services/generalProject.ts
+++ b/app/src/services/generalProject.ts
@@ -14,10 +14,10 @@ import type {
   CurrentContext,
   GeneralProject,
   GeneralProjectIntake,
-  GeneralProjectSearchParameters,
   GeneralProjectStatistics,
   Maybe,
-  PatchGeneralProjectRequest
+  PatchGeneralProjectRequest,
+  SearchGeneralProjectRequest
 } from '../types/index.ts';
 
 export const createGeneralProjectService = async (
@@ -149,7 +149,7 @@ export const getGeneralProjectStatisticsService = async (filters: {
 export const searchGeneralProjects = async (
   currentAuthorization: CurrentAuthorization,
   currentContext: CurrentContext,
-  params: GeneralProjectSearchParameters
+  params: SearchGeneralProjectRequest
 ): Promise<GeneralProject[]> => {
   return await unitOfWork.execute(async ({ activityContact, contact, generalProject }) => {
     const result = await generalProject.search(params);

--- a/app/src/services/housingProject.ts
+++ b/app/src/services/housingProject.ts
@@ -4,7 +4,7 @@ import { generateHousingProjectData } from '../domains/housingProject.ts';
 import { upsertPermitTracking } from '../domains/permitTracking.ts';
 import { emailProjectConfirmation } from '../domains/project.ts';
 import { filterActivityResponseByScope } from '../parsers/responseFiltering.ts';
-import { Initiative } from '../utils/enums/application.ts';
+import { BasicResponse, Initiative } from '../utils/enums/application.ts';
 import { confirmationTemplateHousingSubmission } from '../utils/templates.ts';
 
 import type { Prisma } from '@prisma/client';
@@ -242,11 +242,20 @@ export const patchHousingProjectService = async (
   data: PatchHousingProjectRequest
 ): Promise<HousingProject> => {
   return await unitOfWork.execute(async ({ housingProject }) => {
+    const current = await housingProject.findFirstOrThrow({ where: { housingProjectId } });
+
+    const financiallySupported = [
+      data.financiallySupportedBc ?? current.financiallySupportedBc,
+      data.financiallySupportedIndigenous ?? current.financiallySupportedIndigenous,
+      data.financiallySupportedNonProfit ?? current.financiallySupportedNonProfit,
+      data.financiallySupportedHousingCoop ?? current.financiallySupportedHousingCoop
+    ].includes(BasicResponse.YES);
+
     await housingProject.patch(
       {
         housingProjectId
       },
-      data
+      { ...data, financiallySupported }
     );
 
     return await housingProject.findFirstOrThrow({

--- a/app/src/services/housingProject.ts
+++ b/app/src/services/housingProject.ts
@@ -16,7 +16,8 @@ import type {
   HousingProjectIntake,
   HousingProjectSearchParameters,
   HousingProjectStatistics,
-  Maybe
+  Maybe,
+  PatchHousingProjectRequest
 } from '../types/index.ts';
 
 export const createHousingProjectService = async (
@@ -231,17 +232,17 @@ export const submitHousingProjectDraftService = async (
 };
 
 /**
- * Updates a specific housing project
- * @param data Housing project to update
+ * Patches a specific housing project
  * @param housingProjectId ID of the project to update
+ * @param data Housing project to update
  * @returns A Promise that resolves to the updated housing project
  */
-export const updateHousingProjectService = async (
-  data: Omit<Prisma.housing_projectUpdateInput, 'housingProjectId'>,
-  housingProjectId: string
+export const patchHousingProjectService = async (
+  housingProjectId: string,
+  data: PatchHousingProjectRequest
 ): Promise<HousingProject> => {
   return await unitOfWork.execute(async ({ housingProject }) => {
-    await housingProject.update(
+    await housingProject.patch(
       {
         housingProjectId
       },

--- a/app/src/services/housingProject.ts
+++ b/app/src/services/housingProject.ts
@@ -14,8 +14,8 @@ import type {
   CurrentContext,
   HousingProject,
   HousingProjectIntake,
-  HousingProjectSearchParameters,
   HousingProjectStatistics,
+  SearchHousingProjectRequest,
   Maybe,
   PatchHousingProjectRequest
 } from '../types/index.ts';
@@ -168,7 +168,7 @@ export const listHousingProjectsService = async (
 export const searchHousingProjects = async (
   currentAuthorization: CurrentAuthorization,
   currentContext: CurrentContext,
-  params: HousingProjectSearchParameters
+  params: SearchHousingProjectRequest
 ): Promise<HousingProject[]> => {
   return await unitOfWork.execute(async ({ activityContact, contact, housingProject }) => {
     const result = await housingProject.search(params);

--- a/app/src/services/noteHistory.ts
+++ b/app/src/services/noteHistory.ts
@@ -10,7 +10,8 @@ import type {
   CurrentAuthorization,
   CurrentContext,
   NoteHistory,
-  NoteHistoryBase
+  NoteHistoryBase,
+  PatchNoteHistoryRequest
 } from '../types/index.ts';
 import type { Initiative, Resource } from '../utils/enums/application.ts';
 
@@ -118,39 +119,37 @@ export const listNoteHistoriesService = async (
 };
 
 /**
- * Update a note history
+ * Patches a note history
+ * @param noteHistoryId - ID of the note history to update
  * @param currentAuthorization - The authorization of the current authorized user
  * @param currentContext - Context data of current request
- * @param data - The note history to update
+ * @param data - The note history fields to update
  * @param noteStr - Optional string to be added as a note
- * @param resource - The type of Resource the note history belongs to
+ * @param resource - Control-flow flag identifying which project/enquiry type the note history belongs to;
+ *   not a persisted note_history column, only used to route the bring-forward notification email
  * @returns A Promise that resolves to the updated resource
  */
-export const updateNoteHistoryService = async (
+export const patchNoteHistoryService = async (
+  noteHistoryId: string,
   currentAuthorization: CurrentAuthorization,
   currentContext: CurrentContext,
-  data: NoteHistoryBase,
+  data: Omit<PatchNoteHistoryRequest, 'noteHistoryId' | 'note' | 'resource'>,
   noteStr: string | undefined,
   resource: Resource
 ): Promise<NoteHistory> => {
   return await unitOfWork.execute(
     async ({ electrificationProject, generalProject, housingProject, note, noteHistory, subjectGroup, user }) => {
-      await noteHistory.update(
-        {
-          noteHistoryId: data.noteHistoryId
-        },
-        data
-      );
+      await noteHistory.update({ noteHistoryId }, data);
 
-      if (note) {
+      if (noteStr) {
         await note.create({
-          noteHistoryId: data.noteHistoryId,
+          noteHistoryId,
           noteId: randomUUID(),
           note: noteStr
         });
       }
 
-      const response = await noteHistory.findFirstOrThrow({ where: { noteHistoryId: data.noteHistoryId } });
+      const response = await noteHistory.findFirstOrThrow({ where: { noteHistoryId } });
 
       const isNavigator = !!currentAuthorization?.groups.some((group) => group.name === GroupName.NAVIGATOR);
       if (isNavigator)

--- a/app/src/services/noteHistory.ts
+++ b/app/src/services/noteHistory.ts
@@ -133,7 +133,7 @@ export const patchNoteHistoryService = async (
   noteHistoryId: string,
   currentAuthorization: CurrentAuthorization,
   currentContext: CurrentContext,
-  data: Omit<PatchNoteHistoryRequest, 'noteHistoryId' | 'note' | 'resource'>,
+  data: Omit<PatchNoteHistoryRequest, 'note' | 'resource'>,
   noteStr: string | undefined,
   resource: Resource
 ): Promise<NoteHistory> => {

--- a/app/src/types/api/dto.ts
+++ b/app/src/types/api/dto.ts
@@ -51,8 +51,7 @@ export type PutRequestDTO<T, S extends ResourceSchemaConfig<T>> = Simplify<
 >;
 
 export type PatchRequestDTO<T, S extends ResourceSchemaConfig<T>> = Simplify<
-  Pick<T, S['ids']> &
-    Partial<Omit<ClientWritable<T>, S['ids'] | (S['immutable'] extends keyof T ? S['immutable'] : never)>>
+  Partial<Omit<ClientWritable<T>, S['ids'] | (S['immutable'] extends keyof T ? S['immutable'] : never)>>
 >;
 
 export type UpsertRequestDTO<T, S extends ResourceSchemaConfig<T>> = Simplify<

--- a/app/src/types/api/requests.ts
+++ b/app/src/types/api/requests.ts
@@ -1,5 +1,6 @@
 import type { ParsedQs } from 'qs';
 import type {
+  CreateRequestDTO,
   DeleteRequestDTO,
   GetRequestDTO,
   ListRequestDTO,
@@ -8,18 +9,33 @@ import type {
   UpsertRequestDTO
 } from './dto.ts';
 import type {
+  ContactBase,
   ElectrificationProjectBase,
   EnquiryBase,
   GeneralProjectBase,
   HousingProjectBase,
+  NoteHistoryBase,
   Permit,
   PermitBase,
   Stamps
 } from './resources.ts';
 import type { PaginationOptions } from '../common.ts';
 import type { Nullable } from '../utils.ts';
-import type { GroupName, Initiative } from '../../utils/enums/application.ts';
+import type { GroupName, Initiative, Resource } from '../../utils/enums/application.ts';
 import type { EmailTemplate } from '../../utils/templates';
+
+/**
+ * Contact
+ */
+
+interface ContactBaseSchema extends ResourceSchemaConfig<ContactBase> {
+  ids: 'contactId';
+  immutable: 'contactId';
+  serverGenerated: 'contactId';
+}
+
+export type CreateContactRequest = CreateRequestDTO<ContactBase, ContactBaseSchema>;
+export type UpsertContactRequest = UpsertRequestDTO<ContactBase, ContactBaseSchema>;
 
 /**
  * Electrification Project
@@ -93,6 +109,32 @@ interface HousingProjectBaseSchema extends ResourceSchemaConfig<HousingProjectBa
 }
 
 export type PatchHousingProjectRequest = PatchRequestDTO<HousingProjectBase, HousingProjectBaseSchema>;
+
+/**
+ * Note History
+ */
+
+interface NoteHistoryBaseSchema extends ResourceSchemaConfig<NoteHistoryBase> {
+  ids: 'noteHistoryId';
+  immutable: 'noteHistoryId';
+  serverGenerated: 'noteHistoryId';
+}
+interface NoteHistoryBringForwardSchema extends NoteHistoryBaseSchema {
+  query: {
+    bringForwardState: Nullable<string>;
+  };
+}
+interface NoteHistoryQuerySchema extends NoteHistoryBaseSchema {
+  scope: 'activityId';
+}
+export type CreateNoteHistoryRequest = CreateRequestDTO<NoteHistoryBase, NoteHistoryBaseSchema> & { note: string };
+export type ListBringForwardsRequest = ListRequestDTO<NoteHistoryBase, NoteHistoryBringForwardSchema>;
+export type ListNoteHistoriesRequest = ListRequestDTO<NoteHistoryBase, NoteHistoryQuerySchema>;
+export type PatchNoteHistoryRequest = PatchRequestDTO<NoteHistoryBase, NoteHistoryBaseSchema> & {
+  note: string | undefined;
+  resource: Resource;
+};
+export type DeleteNoteHistoryRequest = DeleteRequestDTO<NoteHistoryBase, NoteHistoryBaseSchema>;
 
 /**
  * Permit

--- a/app/src/types/api/requests.ts
+++ b/app/src/types/api/requests.ts
@@ -1,10 +1,98 @@
 import type { ParsedQs } from 'qs';
-import type { DeleteRequestDTO, GetRequestDTO, ListRequestDTO, ResourceSchemaConfig, UpsertRequestDTO } from './dto.ts';
-import type { Permit, PermitBase, Stamps } from './resources.ts';
+import type {
+  DeleteRequestDTO,
+  GetRequestDTO,
+  ListRequestDTO,
+  PatchRequestDTO,
+  ResourceSchemaConfig,
+  UpsertRequestDTO
+} from './dto.ts';
+import type {
+  ElectrificationProjectBase,
+  EnquiryBase,
+  GeneralProjectBase,
+  HousingProjectBase,
+  Permit,
+  PermitBase,
+  Stamps
+} from './resources.ts';
 import type { PaginationOptions } from '../common.ts';
 import type { Nullable } from '../utils.ts';
 import type { GroupName, Initiative } from '../../utils/enums/application.ts';
 import type { EmailTemplate } from '../../utils/templates';
+
+/**
+ * Electrification Project
+ */
+
+interface ElectrificationProjectBaseSchema extends ResourceSchemaConfig<ElectrificationProjectBase> {
+  ids: 'electrificationProjectId';
+  immutable: 'activityId' | 'electrificationProjectId';
+  serverGenerated: 'activityId' | 'electrificationProjectId';
+  query: {
+    activityId: string[];
+    createdBy: string[];
+    includeUser: boolean;
+    electrificationProjectId: string[];
+    projectType: string[];
+    projectCategory: string[];
+  };
+}
+
+export type PatchElectrificationProjectRequest = PatchRequestDTO<
+  ElectrificationProjectBase,
+  ElectrificationProjectBaseSchema
+>;
+
+/**
+ * Enquiry
+ */
+
+interface EnquiryBaseSchema extends ResourceSchemaConfig<EnquiryBase> {
+  ids: 'enquiryId';
+  immutable: 'activityId' | 'enquiryId';
+  serverGenerated: 'activityId' | 'enquiryId';
+}
+
+export type PatchEnquiryRequest = PatchRequestDTO<EnquiryBase, EnquiryBaseSchema>;
+
+/**
+ * General Project
+ */
+
+interface GeneralProjectBaseSchema extends ResourceSchemaConfig<GeneralProjectBase> {
+  ids: 'generalProjectId';
+  immutable: 'activityId' | 'generalProjectId';
+  serverGenerated: 'activityId' | 'generalProjectId';
+  query: {
+    activityId: string[];
+    createdBy: string[];
+    includeUser: boolean;
+    generalProjectId: string[];
+    submissionType: string[];
+  };
+}
+
+export type PatchGeneralProjectRequest = PatchRequestDTO<GeneralProjectBase, GeneralProjectBaseSchema>;
+
+/**
+ * Housing Project
+ */
+
+interface HousingProjectBaseSchema extends ResourceSchemaConfig<HousingProjectBase> {
+  ids: 'housingProjectId';
+  immutable: 'activityId' | 'housingProjectId';
+  serverGenerated: 'activityId' | 'housingProjectId';
+  query: {
+    activityId: string[];
+    createdBy: string[];
+    includeUser: boolean;
+    housingProjectId: string[];
+    submissionType: string[];
+  };
+}
+
+export type PatchHousingProjectRequest = PatchRequestDTO<HousingProjectBase, HousingProjectBaseSchema>;
 
 /**
  * Permit

--- a/app/src/types/api/requests.ts
+++ b/app/src/types/api/requests.ts
@@ -145,7 +145,7 @@ export type SubmitDraftHousingProjectRequest = HousingProjectIntake;
 
 interface NoteHistoryBaseSchema extends ResourceSchemaConfig<NoteHistoryBase> {
   ids: 'noteHistoryId';
-  immutable: 'noteHistoryId';
+  immutable: 'activityId' | 'noteHistoryId';
   serverGenerated: 'noteHistoryId';
 }
 interface NoteHistoryBringForwardSchema extends NoteHistoryBaseSchema {

--- a/app/src/types/api/requests.ts
+++ b/app/src/types/api/requests.ts
@@ -20,9 +20,10 @@ import type {
   Stamps
 } from './resources.ts';
 import type { PaginationOptions } from '../common.ts';
-import type { Nullable } from '../utils.ts';
+import type { Nullable, PartialFields } from '../utils.ts';
 import type { GroupName, Initiative, Resource } from '../../utils/enums/application.ts';
 import type { EmailTemplate } from '../../utils/templates';
+import { ElectrificationProjectIntake, GeneralProjectIntake, HousingProjectIntake } from '../intakes.ts';
 
 /**
  * Contact
@@ -55,10 +56,19 @@ interface ElectrificationProjectBaseSchema extends ResourceSchemaConfig<Electrif
   };
 }
 
+export type CreateElectrificationProjectRequest = CreateRequestDTO<
+  Partial<ElectrificationProjectBase>,
+  ElectrificationProjectBaseSchema
+>;
+export type SearchElectrificationProjectRequest = ListRequestDTO<
+  Partial<ElectrificationProjectBase>,
+  ElectrificationProjectBaseSchema
+>;
 export type PatchElectrificationProjectRequest = PatchRequestDTO<
   ElectrificationProjectBase,
   ElectrificationProjectBaseSchema
 >;
+export type SubmitDraftElectrificationProjectRequest = ElectrificationProjectIntake;
 
 /**
  * Enquiry
@@ -69,8 +79,21 @@ interface EnquiryBaseSchema extends ResourceSchemaConfig<EnquiryBase> {
   immutable: 'activityId' | 'enquiryId';
   serverGenerated: 'activityId' | 'enquiryId';
 }
-
+interface EnquiryListRelatedSchema extends EnquiryBaseSchema {
+  scope: 'activityId';
+}
+interface EnquirySearchSchema extends EnquiryBaseSchema {
+  query: { activityId: string[]; createdBy: string[]; enquiryId: string[]; includeUser: boolean };
+}
+export type CreateEnquiryRequest = PartialFields<
+  Pick<EnquiryBase, 'enquiryDescription' | 'relatedActivityId' | 'submissionType'> & { contact: ContactBase },
+  'submissionType'
+>;
+export type GetEnquiryRequest = GetRequestDTO<EnquiryBase, EnquiryBaseSchema>;
+export type ListRelatedEnquiriesRequest = ListRequestDTO<EnquiryBase, EnquiryListRelatedSchema>;
+export type SearchEnquiriesRequest = ListRequestDTO<EnquiryBase, EnquirySearchSchema>;
 export type PatchEnquiryRequest = PatchRequestDTO<EnquiryBase, EnquiryBaseSchema>;
+export type DeleteEnquiryRequest = DeleteRequestDTO<EnquiryBase, EnquiryBaseSchema>;
 
 /**
  * General Project
@@ -89,7 +112,10 @@ interface GeneralProjectBaseSchema extends ResourceSchemaConfig<GeneralProjectBa
   };
 }
 
+export type CreateGeneralProjectRequest = CreateRequestDTO<Partial<GeneralProjectBase>, GeneralProjectBaseSchema>;
+export type SearchGeneralProjectRequest = ListRequestDTO<Partial<GeneralProjectBase>, GeneralProjectBaseSchema>;
 export type PatchGeneralProjectRequest = PatchRequestDTO<GeneralProjectBase, GeneralProjectBaseSchema>;
+export type SubmitDraftGeneralProjectRequest = GeneralProjectIntake;
 
 /**
  * Housing Project
@@ -108,7 +134,10 @@ interface HousingProjectBaseSchema extends ResourceSchemaConfig<HousingProjectBa
   };
 }
 
+export type CreateHousingProjectRequest = CreateRequestDTO<Partial<HousingProjectBase>, HousingProjectBaseSchema>;
+export type SearchHousingProjectRequest = ListRequestDTO<Partial<HousingProjectBase>, HousingProjectBaseSchema>;
 export type PatchHousingProjectRequest = PatchRequestDTO<HousingProjectBase, HousingProjectBaseSchema>;
+export type SubmitDraftHousingProjectRequest = HousingProjectIntake;
 
 /**
  * Note History
@@ -171,15 +200,6 @@ export interface ContactSearchParameters {
   includeActivities?: boolean;
 }
 
-export interface ElectrificationProjectSearchParameters {
-  activityId?: string[];
-  createdBy?: string[];
-  electrificationProjectId?: string[];
-  projectType?: string[];
-  projectCategory?: string[];
-  includeUser?: boolean;
-}
-
 export interface Email {
   bcc?: string[];
   bodyType: string;
@@ -200,29 +220,6 @@ export interface EmailAttachment {
   contentType: string;
   encoding: string;
   filename: string;
-}
-
-export interface EnquirySearchParameters {
-  activityId?: string[];
-  createdBy?: string[];
-  enquiryId?: string[];
-  includeUser?: boolean;
-}
-
-export interface GeneralProjectSearchParameters {
-  activityId?: string[];
-  createdBy?: string[];
-  generalProjectId?: string[];
-  submissionType?: string[];
-  includeUser?: boolean;
-}
-
-export interface HousingProjectSearchParameters {
-  activityId?: string[];
-  createdBy?: string[];
-  housingProjectId?: string[];
-  submissionType?: string[];
-  includeUser?: boolean;
 }
 
 export interface IdirSearchParameters extends ParsedQs {

--- a/app/src/types/api/responses.ts
+++ b/app/src/types/api/responses.ts
@@ -1,4 +1,8 @@
 import type { PermitStage, PermitState, PiesOnHold } from '../../db/codes/enums.ts';
+import type { Contact, Enquiry } from './resources.ts';
+
+/** Create bolts a top-level `contact` onto the response; not a real Enquiry relation, kept off `Enquiry` itself. */
+export type CreateEnquiryResponse = Enquiry & { contact: Contact };
 
 export interface PeachSummary {
   stage: PermitStage;

--- a/app/src/validators/ats.ts
+++ b/app/src/validators/ats.ts
@@ -36,7 +36,7 @@ const enquiryBody = {
 };
 
 const atsEnquirySubmissionFields = {
-  addedToAts: Joi.boolean().required(),
+  addedToAts: Joi.boolean(),
   // ATS DDL: CLIENT_ID NUMBER(38,0) - may contain up to 38 digits
   atsClientId: Joi.number().integer().min(0).allow(null),
   atsEnquiryId: Joi.number().integer().min(0).allow(null)

--- a/app/src/validators/electrificationProject.ts
+++ b/app/src/validators/electrificationProject.ts
@@ -75,12 +75,12 @@ const schema = {
       projectCategory: Joi.array().items(Joi.string().custom(requireValidCode.ElectrificationProjectCategory))
     })
   },
-  updateElectrificationProject: {
+  patchElectrificationProject: {
     body: Joi.object({
-      projectName: Joi.string().required().max(255).trim(),
+      projectName: Joi.string().max(255).trim(),
       companyNameRegistered: Joi.string().max(255).trim().allow(null),
       companyIdRegistered: Joi.string().max(255).trim().allow(null),
-      projectType: Joi.string().required().custom(requireValidCode.ElectrificationProjectType),
+      projectType: Joi.string().custom(requireValidCode.ElectrificationProjectType),
       bcHydroNumber: Joi.string().max(255).trim().allow(null),
       projectDescription: Joi.when('projectType', {
         is: ProjectType.OTHER,
@@ -98,13 +98,11 @@ const schema = {
         .allow(null),
       locationDescription: Joi.string().max(4000).allow(null),
       astNotes: Joi.string().max(4000).allow(null),
-      queuePriority: Joi.number().integer().required().min(0).max(3),
-      submissionType: Joi.string()
-        .required()
-        .valid(...SUBMISSION_TYPE_LIST),
+      queuePriority: Joi.number().integer().min(0).max(3),
+      submissionType: Joi.string().valid(...SUBMISSION_TYPE_LIST),
       applicationStatus: Joi.string().valid(...APPLICATION_STATUS_LIST),
       ...atsValidator.atsEnquirySubmissionFields,
-      aaiUpdated: Joi.boolean().required()
+      aaiUpdated: Joi.boolean()
     }),
     params: Joi.object({
       electrificationProjectId: uuidv4.required()
@@ -120,5 +118,5 @@ export default {
   getStatistics: validate(schema.getStatistics),
   getElectrificationProject: validate(schema.getElectrificationProject),
   searcElectrificationProjects: validate(schema.searchElectrificationProjects),
-  updateElectrificationProject: validate(schema.updateElectrificationProject)
+  patchElectrificationProject: validate(schema.patchElectrificationProject)
 };

--- a/app/src/validators/enquiry.ts
+++ b/app/src/validators/enquiry.ts
@@ -34,7 +34,7 @@ const schema = {
       includeUser: Joi.boolean()
     })
   },
-  updateEnquiry: {
+  patchEnquiry: {
     body: Joi.object({
       submissionType: Joi.string().allow(null),
       relatedActivityId: Joi.string().max(255).allow(null),
@@ -51,5 +51,5 @@ export default {
   createEnquiry: validate(schema.createEnquiry),
   deleteEnquiry: validate(schema.deleteEnquiry),
   searchEnquiries: validate(schema.searchEnquiries),
-  updateEnquiry: validate(schema.updateEnquiry)
+  patchEnquiry: validate(schema.patchEnquiry)
 };

--- a/app/src/validators/generalProject.ts
+++ b/app/src/validators/generalProject.ts
@@ -83,16 +83,14 @@ const schema = {
       submissionType: Joi.array().items(...SUBMISSION_TYPE_LIST)
     })
   },
-  updateGeneralProject: {
+  patchGeneralProject: {
     body: Joi.object({
-      queuePriority: Joi.number().required().integer().min(0).max(3),
-      submissionType: Joi.string()
-        .required()
-        .valid(...SUBMISSION_TYPE_LIST),
+      queuePriority: Joi.number().integer().min(0).max(3),
+      submissionType: Joi.string().valid(...SUBMISSION_TYPE_LIST),
       companyNameRegistered: Joi.string().allow(null),
       companyIdRegistered: Joi.string().allow(null),
-      projectName: Joi.string().required(),
-      activityType: Joi.string().required(),
+      projectName: Joi.string(),
+      activityType: Joi.string(),
       projectDescription: Joi.string().allow(null),
       streetAddress: Joi.string().allow(null).max(255),
       locality: Joi.string().allow(null).max(255),
@@ -101,11 +99,11 @@ const schema = {
       latitude: Joi.number().allow(null).max(255),
       longitude: Joi.number().allow(null).max(255),
       geomarkUrl: Joi.string().allow(null).max(255),
-      naturalDisaster: Joi.boolean().required(),
+      naturalDisaster: Joi.boolean(),
       projectLocationDescription: Joi.string().allow(null).max(4000),
-      ...atsValidator.atsEnquirySubmissionFields,
-      addedToAts: Joi.optional(),
-      aaiUpdated: Joi.boolean().required(),
+      atsClientId: atsValidator.atsEnquirySubmissionFields.atsClientId,
+      atsEnquiryId: atsValidator.atsEnquirySubmissionFields.atsEnquiryId,
+      aaiUpdated: Joi.boolean(),
       astNotes: Joi.string().allow(null).max(4000),
       assignedUserId: uuidv4.allow(null),
       applicationStatus: Joi.string().valid(...APPLICATION_STATUS_LIST),
@@ -126,5 +124,5 @@ export default {
   getStatistics: validate(schema.getStatistics),
   getGeneralProject: validate(schema.getGeneralProject),
   searchGeneralProjects: validate(schema.searchGeneralProjects),
-  updateGeneralProject: validate(schema.updateGeneralProject)
+  patchGeneralProject: validate(schema.patchGeneralProject)
 };

--- a/app/src/validators/housingProject.ts
+++ b/app/src/validators/housingProject.ts
@@ -88,16 +88,14 @@ const schema = {
       submissionType: Joi.array().items(...SUBMISSION_TYPE_LIST)
     })
   },
-  updateHousingProject: {
+  patchHousingProject: {
     body: Joi.object({
       consentToFeedback: Joi.boolean(),
-      queuePriority: Joi.number().required().integer().min(0).max(3),
-      submissionType: Joi.string()
-        .required()
-        .valid(...SUBMISSION_TYPE_LIST),
+      queuePriority: Joi.number().integer().min(0).max(3),
+      submissionType: Joi.string().valid(...SUBMISSION_TYPE_LIST),
       companyNameRegistered: Joi.string().allow(null),
       companyIdRegistered: Joi.string().allow(null),
-      projectName: Joi.string().required(),
+      projectName: Joi.string(),
       projectDescription: Joi.string().allow(null),
       singleFamilyUnits: Joi.string()
         .allow(null)
@@ -113,9 +111,7 @@ const schema = {
           .valid(...NUM_RESIDENTIAL_UNITS_LIST),
         otherwise: Joi.string().allow(null)
       }),
-      hasRentalUnits: Joi.string()
-        .required()
-        .valid(...YES_NO_UNSURE_LIST),
+      hasRentalUnits: Joi.string().valid(...YES_NO_UNSURE_LIST),
       rentalUnits: Joi.when('hasRentalUnits', {
         is: BasicResponse.YES,
         then: Joi.string()
@@ -123,28 +119,20 @@ const schema = {
           .valid(...NUM_RESIDENTIAL_UNITS_LIST),
         otherwise: Joi.string().allow(null)
       }),
-      financiallySupportedBc: Joi.string()
-        .required()
-        .valid(...YES_NO_UNSURE_LIST),
-      financiallySupportedIndigenous: Joi.string()
-        .required()
-        .valid(...YES_NO_UNSURE_LIST),
+      financiallySupportedBc: Joi.string().valid(...YES_NO_UNSURE_LIST),
+      financiallySupportedIndigenous: Joi.string().valid(...YES_NO_UNSURE_LIST),
       indigenousDescription: Joi.when('financiallySupportedIndigenous', {
         is: BasicResponse.YES,
         then: Joi.string().required().max(255),
         otherwise: Joi.string().allow(null)
       }),
-      financiallySupportedNonProfit: Joi.string()
-        .required()
-        .valid(...YES_NO_UNSURE_LIST),
+      financiallySupportedNonProfit: Joi.string().valid(...YES_NO_UNSURE_LIST),
       nonProfitDescription: Joi.when('financiallySupportedNonProfit', {
         is: BasicResponse.YES,
         then: Joi.string().required().max(255),
         otherwise: Joi.string().allow(null)
       }),
-      financiallySupportedHousingCoop: Joi.string()
-        .required()
-        .valid(...YES_NO_UNSURE_LIST),
+      financiallySupportedHousingCoop: Joi.string().valid(...YES_NO_UNSURE_LIST),
       housingCoopDescription: Joi.when('financiallySupportedHousingCoop', {
         is: BasicResponse.YES,
         then: Joi.string().required().max(255),
@@ -157,12 +145,12 @@ const schema = {
       latitude: Joi.number().allow(null).max(255),
       longitude: Joi.number().allow(null).max(255),
       geomarkUrl: Joi.string().allow(null).max(255),
-      naturalDisaster: Joi.boolean().required(),
+      naturalDisaster: Joi.boolean(),
       projectLocationDescription: Joi.string().allow(null).max(4000),
       ...atsValidator.atsEnquirySubmissionFields,
-      ltsaCompleted: Joi.boolean().required(),
-      bcOnlineCompleted: Joi.boolean().required(),
-      aaiUpdated: Joi.boolean().required(),
+      ltsaCompleted: Joi.boolean(),
+      bcOnlineCompleted: Joi.boolean(),
+      aaiUpdated: Joi.boolean(),
       astNotes: Joi.string().allow(null).max(4000),
       assignedUserId: uuidv4.allow(null),
       applicationStatus: Joi.string().valid(...APPLICATION_STATUS_LIST)
@@ -180,6 +168,6 @@ export default {
   deleteDraft: validate(schema.deleteDraft),
   getStatistics: validate(schema.getStatistics),
   getHousingProject: validate(schema.getHousingProject),
-  searchHousingProjects: validate(schema.searchHousingProjects),
-  updateHousingProject: validate(schema.updateHousingProject)
+  patchHousingProject: validate(schema.patchHousingProject),
+  searchHousingProjects: validate(schema.searchHousingProjects)
 };

--- a/app/src/validators/noteHistory.ts
+++ b/app/src/validators/noteHistory.ts
@@ -30,7 +30,6 @@ const schema = {
   },
   patchNoteHistory: {
     body: Joi.object({
-      activityId: activityId,
       bringForwardDate: Joi.date().iso().allow(null),
       bringForwardState: Joi.string()
         .valid(...BRING_FORWARD_TYPE_LIST)

--- a/app/src/validators/noteHistory.ts
+++ b/app/src/validators/noteHistory.ts
@@ -28,7 +28,7 @@ const schema = {
       activityId: activityId
     })
   },
-  updateNoteHistory: {
+  patchNoteHistory: {
     body: Joi.object({
       activityId: activityId,
       bringForwardDate: Joi.date().iso().allow(null),
@@ -39,13 +39,12 @@ const schema = {
       escalateToDirector: Joi.boolean(),
       escalationType: Joi.string().custom(requireValidCode.EscalationType).allow(null),
       note: Joi.string().allow(null),
-      noteHistoryId: uuidv4.allow(null),
       resource: Joi.string()
         .required()
         .valid(Resource.ELECTRIFICATION_PROJECT, Resource.ENQUIRY, Resource.GENERAL_PROJECT, Resource.HOUSING_PROJECT),
       shownToProponent: Joi.boolean(),
-      title: Joi.string().max(255).required(),
-      type: Joi.string().max(255).required()
+      title: Joi.string().max(255),
+      type: Joi.string().max(255)
     }),
     params: Joi.object({
       noteHistoryId: uuidv4.required()
@@ -56,5 +55,5 @@ const schema = {
 export default {
   createNoteHistory: validate(schema.createNoteHistory),
   listNoteHistory: validate(schema.listNoteHistory),
-  updateNoteHistory: validate(schema.updateNoteHistory)
+  patchNoteHistory: validate(schema.patchNoteHistory)
 };

--- a/app/tests/unit/controllers/contact.test.ts
+++ b/app/tests/unit/controllers/contact.test.ts
@@ -160,7 +160,7 @@ describe('searchContactsController', () => {
         email: 'john@example.com',
         includeActivities: 'true'
       }
-    } as unknown as Request<never, never, ContactSearchParameters | undefined, never>;
+    } as unknown as Request<never, never, ContactSearchParameters, never>;
 
     searchSpy.mockResolvedValue([TEST_CONTACT_1]);
 
@@ -180,7 +180,7 @@ describe('searchContactsController', () => {
   it('handles undefined body', async () => {
     const req = {
       body: undefined
-    } as unknown as Request<never, never, ContactSearchParameters | undefined, never>;
+    } as unknown as Request<never, never, ContactSearchParameters, never>;
 
     searchSpy.mockResolvedValue([]);
 

--- a/app/tests/unit/controllers/electrificationProject.test.ts
+++ b/app/tests/unit/controllers/electrificationProject.test.ts
@@ -16,9 +16,9 @@ import {
   getElectrificationProjectStatisticsController,
   listElectrificationProjectActivityIdsController,
   listElectrificationProjectsController,
+  patchElectrificationProjectController,
   searchElectrificationProjectsController,
   submitElectrificationProjectDraftController,
-  updateElectrificationProjectController,
   upsertElectrificationProjectDraftController
 } from '../../../src/controllers/electrificationProject.ts';
 import * as activityService from '../../../src/services/activity.ts';
@@ -27,7 +27,6 @@ import * as electrificationProjectService from '../../../src/services/electrific
 import { Initiative } from '../../../src/utils/enums/application.ts';
 import { DraftCode } from '../../../src/utils/enums/projectCommon.ts';
 
-import type { Prisma } from '@prisma/client';
 import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
 import type {
@@ -37,6 +36,7 @@ import type {
   ElectrificationProjectSearchParameters,
   ElectrificationProjectStatistics,
   LocalContext,
+  PatchElectrificationProjectRequest,
   StatisticsFilters
 } from '../../../src/types/index.ts';
 
@@ -250,22 +250,22 @@ describe('searchElectrificationProjectsController', () => {
   });
 });
 
-describe('updateElectrificationProjectController', () => {
-  const updateSpy = vi.spyOn(electrificationProjectService, 'updateElectrificationProjectService');
+describe('patchElectrificationProjectController', () => {
+  const updateSpy = vi.spyOn(electrificationProjectService, 'patchElectrificationProjectService');
 
   it('calls the service with update data and projectId then responds 200', async () => {
     const updateData = { projectName: 'Updated Name' };
     const req = {
       params: { electrificationProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' },
       body: updateData
-    } as unknown as Request<{ electrificationProjectId: string }, never, Prisma.electrification_projectUpdateInput>;
+    } as unknown as Request<{ electrificationProjectId: string }, never, PatchElectrificationProjectRequest>;
 
     updateSpy.mockResolvedValue(TEST_ELECTRIFICATION_PROJECT_1 as ElectrificationProject);
 
-    await updateElectrificationProjectController(req, res as unknown as Response);
+    await patchElectrificationProjectController(req, res as unknown as Response);
 
     expect(updateSpy).toHaveBeenCalledTimes(1);
-    expect(updateSpy).toHaveBeenCalledWith(updateData, req.params.electrificationProjectId);
+    expect(updateSpy).toHaveBeenCalledWith(req.params.electrificationProjectId, updateData);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(TEST_ELECTRIFICATION_PROJECT_1);
   });

--- a/app/tests/unit/controllers/electrificationProject.test.ts
+++ b/app/tests/unit/controllers/electrificationProject.test.ts
@@ -33,7 +33,7 @@ import type {
   Draft,
   ElectrificationProject,
   ElectrificationProjectIntake,
-  ElectrificationProjectSearchParameters,
+  SearchElectrificationProjectRequest,
   ElectrificationProjectStatistics,
   LocalContext,
   PatchElectrificationProjectRequest,
@@ -206,7 +206,7 @@ describe('searchElectrificationProjectsController', () => {
   it('calls the service with search params and context then responds 200', async () => {
     const req = {
       body: { projectName: 'test' }
-    } as unknown as Request<never, never, ElectrificationProjectSearchParameters | undefined, never>;
+    } as unknown as Request<never, never, SearchElectrificationProjectRequest | undefined, never>;
 
     searchSpy.mockResolvedValue([TEST_ELECTRIFICATION_PROJECT_1 as ElectrificationProject]);
 
@@ -231,7 +231,7 @@ describe('searchElectrificationProjectsController', () => {
   it('coerces includeUser query parameter to boolean', async () => {
     const req = {
       body: { includeUser: 'true' }
-    } as unknown as Request<never, never, ElectrificationProjectSearchParameters | undefined, never>;
+    } as unknown as Request<never, never, SearchElectrificationProjectRequest | undefined, never>;
 
     searchSpy.mockResolvedValue([TEST_ELECTRIFICATION_PROJECT_1 as ElectrificationProject]);
 

--- a/app/tests/unit/controllers/electrificationProject.test.ts
+++ b/app/tests/unit/controllers/electrificationProject.test.ts
@@ -206,7 +206,7 @@ describe('searchElectrificationProjectsController', () => {
   it('calls the service with search params and context then responds 200', async () => {
     const req = {
       body: { projectName: 'test' }
-    } as unknown as Request<never, never, SearchElectrificationProjectRequest | undefined, never>;
+    } as unknown as Request<never, never, SearchElectrificationProjectRequest, never>;
 
     searchSpy.mockResolvedValue([TEST_ELECTRIFICATION_PROJECT_1 as ElectrificationProject]);
 
@@ -231,7 +231,7 @@ describe('searchElectrificationProjectsController', () => {
   it('coerces includeUser query parameter to boolean', async () => {
     const req = {
       body: { includeUser: 'true' }
-    } as unknown as Request<never, never, SearchElectrificationProjectRequest | undefined, never>;
+    } as unknown as Request<never, never, SearchElectrificationProjectRequest, never>;
 
     searchSpy.mockResolvedValue([TEST_ELECTRIFICATION_PROJECT_1 as ElectrificationProject]);
 

--- a/app/tests/unit/controllers/enquiry.test.ts
+++ b/app/tests/unit/controllers/enquiry.test.ts
@@ -1,4 +1,5 @@
 import {
+  TEST_CONTACT_1,
   TEST_CURRENT_AUTH_CONTEXT_NAVIGATOR,
   TEST_CURRENT_CONTEXT,
   TEST_ENQUIRY_1,
@@ -19,9 +20,10 @@ import * as enquiryService from '../../../src/services/enquiry.ts';
 import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
 import type {
+  CreateEnquiryResponse,
   Enquiry,
   EnquiryIntake,
-  EnquirySearchParameters,
+  SearchEnquiriesRequest,
   LocalContext,
   PatchEnquiryRequest
 } from '../../../src/types/index.ts';
@@ -48,30 +50,31 @@ beforeEach(() => {
 
 describe('createEnquiryController', () => {
   const createEnquirySpy = vi.spyOn(enquiryService, 'createEnquiryService');
+  const TEST_CREATE_ENQUIRY_RESPONSE: CreateEnquiryResponse = { ...TEST_ENQUIRY_1, contact: TEST_CONTACT_1 };
 
   it('calls the service with the current context and body then responds 201', async () => {
     const req = { body: TEST_ENQUIRY_INTAKE } as unknown as Request<never, never, EnquiryIntake>;
 
-    createEnquirySpy.mockResolvedValue(TEST_ENQUIRY_1);
+    createEnquirySpy.mockResolvedValue(TEST_CREATE_ENQUIRY_RESPONSE);
 
-    await createEnquiryController(req, res as unknown as Response<Enquiry, LocalContext>);
+    await createEnquiryController(req, res as unknown as Response<CreateEnquiryResponse, LocalContext>);
 
     expect(createEnquirySpy).toHaveBeenCalledTimes(1);
     expect(createEnquirySpy).toHaveBeenCalledWith(TEST_CURRENT_CONTEXT, TEST_ENQUIRY_INTAKE);
     expect(res.status).toHaveBeenCalledWith(201);
-    expect(res.json).toHaveBeenCalledWith(TEST_ENQUIRY_1);
+    expect(res.json).toHaveBeenCalledWith(TEST_CREATE_ENQUIRY_RESPONSE);
   });
 
   it('defaults the body to an empty object when undefined', async () => {
     const req = { body: undefined } as unknown as Request<never, never, EnquiryIntake>;
 
-    createEnquirySpy.mockResolvedValue(TEST_ENQUIRY_1);
+    createEnquirySpy.mockResolvedValue(TEST_CREATE_ENQUIRY_RESPONSE);
 
-    await createEnquiryController(req, res as unknown as Response<Enquiry, LocalContext>);
+    await createEnquiryController(req, res as unknown as Response<CreateEnquiryResponse, LocalContext>);
 
     expect(createEnquirySpy).toHaveBeenCalledWith(TEST_CURRENT_CONTEXT, {});
     expect(res.status).toHaveBeenCalledWith(201);
-    expect(res.json).toHaveBeenCalledWith(TEST_ENQUIRY_1);
+    expect(res.json).toHaveBeenCalledWith(TEST_CREATE_ENQUIRY_RESPONSE);
   });
 });
 
@@ -154,7 +157,7 @@ describe('searchEnquiriesController', () => {
   it('coerces includeUser, passes the initiative then responds 200', async () => {
     const req = {
       body: { enquiryId: [TEST_ENQUIRY_1.enquiryId], includeUser: 'true' }
-    } as unknown as Request<never, never, EnquirySearchParameters, never>;
+    } as unknown as Request<never, never, SearchEnquiriesRequest, never>;
     const enquiries: Enquiry[] = [TEST_ENQUIRY_1];
 
     searchEnquiriesSpy.mockResolvedValue(enquiries);
@@ -172,7 +175,7 @@ describe('searchEnquiriesController', () => {
   });
 
   it('leaves includeUser undefined when the body is undefined', async () => {
-    const req = { body: undefined } as unknown as Request<never, never, EnquirySearchParameters | undefined, never>;
+    const req = { body: undefined } as unknown as Request<never, never, SearchEnquiriesRequest, never>;
     const enquiries: Enquiry[] = [TEST_ENQUIRY_1];
 
     searchEnquiriesSpy.mockResolvedValue(enquiries);

--- a/app/tests/unit/controllers/enquiry.test.ts
+++ b/app/tests/unit/controllers/enquiry.test.ts
@@ -10,16 +10,21 @@ import {
   getEnquiryController,
   listEnquiriesController,
   listRelatedEnquiriesController,
-  searchEnquiriesController,
-  updateEnquiryController
+  patchEnquiryController,
+  searchEnquiriesController
 } from '../../../src/controllers/enquiry.ts';
 import * as activityService from '../../../src/services/activity.ts';
 import * as enquiryService from '../../../src/services/enquiry.ts';
 
-import type { Prisma } from '@prisma/client';
 import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
-import type { Enquiry, EnquiryIntake, EnquirySearchParameters, LocalContext } from '../../../src/types/index.ts';
+import type {
+  Enquiry,
+  EnquiryIntake,
+  EnquirySearchParameters,
+  LocalContext,
+  PatchEnquiryRequest
+} from '../../../src/types/index.ts';
 
 vi.mock('config');
 
@@ -185,20 +190,20 @@ describe('searchEnquiriesController', () => {
   });
 });
 
-describe('updateEnquiryController', () => {
-  const updateEnquirySpy = vi.spyOn(enquiryService, 'updateEnquiryService');
+describe('patchEnquiryController', () => {
+  const updateEnquirySpy = vi.spyOn(enquiryService, 'patchEnquiryService');
 
   it('calls the service with the body and enquiryId then responds 200', async () => {
     const req = {
       body: { enquiryDescription: 'updated' },
       params: { enquiryId: TEST_ENQUIRY_1.enquiryId }
-    } as unknown as Request<{ enquiryId: string }, never, Omit<Prisma.enquiryUpdateInput, 'enquiryId'>>;
+    } as unknown as Request<{ enquiryId: string }, never, PatchEnquiryRequest>;
 
     updateEnquirySpy.mockResolvedValue(TEST_ENQUIRY_1);
 
-    await updateEnquiryController(req, res as unknown as Response);
+    await patchEnquiryController(req, res as unknown as Response);
 
-    expect(updateEnquirySpy).toHaveBeenCalledWith({ enquiryDescription: 'updated' }, TEST_ENQUIRY_1.enquiryId);
+    expect(updateEnquirySpy).toHaveBeenCalledWith(TEST_ENQUIRY_1.enquiryId, { enquiryDescription: 'updated' });
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(TEST_ENQUIRY_1);
   });

--- a/app/tests/unit/controllers/generalProject.test.ts
+++ b/app/tests/unit/controllers/generalProject.test.ts
@@ -33,7 +33,7 @@ import type {
   Draft,
   GeneralProject,
   GeneralProjectIntake,
-  GeneralProjectSearchParameters,
+  SearchGeneralProjectRequest,
   GeneralProjectStatistics,
   LocalContext,
   PatchGeneralProjectRequest,
@@ -200,7 +200,7 @@ describe('searchGeneralProjectsController', () => {
   it('calls the service with search params and context then responds 200', async () => {
     const req = {
       body: { projectName: 'test' }
-    } as unknown as Request<never, never, GeneralProjectSearchParameters | undefined, never>;
+    } as unknown as Request<never, never, SearchGeneralProjectRequest | undefined, never>;
 
     searchSpy.mockResolvedValue([TEST_GENERAL_PROJECT_1 as GeneralProject]);
 
@@ -222,7 +222,7 @@ describe('searchGeneralProjectsController', () => {
   it('coerces includeUser query parameter to boolean', async () => {
     const req = {
       body: { includeUser: 'true' }
-    } as unknown as Request<never, never, GeneralProjectSearchParameters | undefined, never>;
+    } as unknown as Request<never, never, SearchGeneralProjectRequest | undefined, never>;
 
     searchSpy.mockResolvedValue([TEST_GENERAL_PROJECT_1 as GeneralProject]);
 

--- a/app/tests/unit/controllers/generalProject.test.ts
+++ b/app/tests/unit/controllers/generalProject.test.ts
@@ -200,7 +200,7 @@ describe('searchGeneralProjectsController', () => {
   it('calls the service with search params and context then responds 200', async () => {
     const req = {
       body: { projectName: 'test' }
-    } as unknown as Request<never, never, SearchGeneralProjectRequest | undefined, never>;
+    } as unknown as Request<never, never, SearchGeneralProjectRequest, never>;
 
     searchSpy.mockResolvedValue([TEST_GENERAL_PROJECT_1 as GeneralProject]);
 
@@ -222,7 +222,7 @@ describe('searchGeneralProjectsController', () => {
   it('coerces includeUser query parameter to boolean', async () => {
     const req = {
       body: { includeUser: 'true' }
-    } as unknown as Request<never, never, SearchGeneralProjectRequest | undefined, never>;
+    } as unknown as Request<never, never, SearchGeneralProjectRequest, never>;
 
     searchSpy.mockResolvedValue([TEST_GENERAL_PROJECT_1 as GeneralProject]);
 

--- a/app/tests/unit/controllers/generalProject.test.ts
+++ b/app/tests/unit/controllers/generalProject.test.ts
@@ -16,9 +16,9 @@ import {
   getGeneralProjectStatisticsController,
   listGeneralProjectActivityIdsController,
   listGeneralProjectsController,
+  patchGeneralProjectController,
   searchGeneralProjectsController,
   submitGeneralProjectDraftController,
-  updateGeneralProjectController,
   upsertGeneralProjectDraftController
 } from '../../../src/controllers/generalProject.ts';
 import * as activityService from '../../../src/services/activity.ts';
@@ -27,7 +27,6 @@ import * as generalProjectService from '../../../src/services/generalProject.ts'
 import { Initiative } from '../../../src/utils/enums/application.ts';
 import { DraftCode } from '../../../src/utils/enums/projectCommon.ts';
 
-import type { Prisma } from '@prisma/client';
 import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
 import type {
@@ -37,6 +36,7 @@ import type {
   GeneralProjectSearchParameters,
   GeneralProjectStatistics,
   LocalContext,
+  PatchGeneralProjectRequest,
   StatisticsFilters
 } from '../../../src/types/index.ts';
 
@@ -238,22 +238,22 @@ describe('searchGeneralProjectsController', () => {
   });
 });
 
-describe('updateGeneralProjectController', () => {
-  const updateSpy = vi.spyOn(generalProjectService, 'updateGeneralProjectService');
+describe('patchGeneralProjectController', () => {
+  const updateSpy = vi.spyOn(generalProjectService, 'patchGeneralProjectService');
 
   it('calls the service with update data and projectId then responds 200', async () => {
     const updateData = { projectName: 'Updated Name' };
     const req = {
       params: { generalProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' },
       body: updateData
-    } as unknown as Request<{ generalProjectId: string }, never, Prisma.general_projectUpdateInput>;
+    } as unknown as Request<{ generalProjectId: string }, never, PatchGeneralProjectRequest>;
 
     updateSpy.mockResolvedValue(TEST_GENERAL_PROJECT_1 as GeneralProject);
 
-    await updateGeneralProjectController(req, res as unknown as Response);
+    await patchGeneralProjectController(req, res as unknown as Response);
 
     expect(updateSpy).toHaveBeenCalledTimes(1);
-    expect(updateSpy).toHaveBeenCalledWith(updateData, req.params.generalProjectId);
+    expect(updateSpy).toHaveBeenCalledWith(req.params.generalProjectId, updateData);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(TEST_GENERAL_PROJECT_1);
   });

--- a/app/tests/unit/controllers/housingProject.test.ts
+++ b/app/tests/unit/controllers/housingProject.test.ts
@@ -253,13 +253,7 @@ describe('patchHousingProjectController', () => {
     await patchHousingProjectController(req, res as unknown as Response);
 
     expect(updateSpy).toHaveBeenCalledTimes(1);
-    expect(updateSpy).toHaveBeenCalledWith(
-      req.params.housingProjectId,
-      expect.objectContaining({
-        projectName: 'Updated Name',
-        financiallySupported: expect.any(Boolean)
-      })
-    );
+    expect(updateSpy).toHaveBeenCalledWith(req.params.housingProjectId, updateData);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(TEST_HOUSING_PROJECT_1);
   });

--- a/app/tests/unit/controllers/housingProject.test.ts
+++ b/app/tests/unit/controllers/housingProject.test.ts
@@ -33,8 +33,8 @@ import type {
   Draft,
   HousingProject,
   HousingProjectIntake,
-  HousingProjectSearchParameters,
   HousingProjectStatistics,
+  SearchHousingProjectRequest,
   LocalContext,
   PatchHousingProjectRequest,
   StatisticsFilters
@@ -200,7 +200,7 @@ describe('searchHousingProjectsController', () => {
   it('calls the service with search params and context then responds 200', async () => {
     const req = {
       body: { projectName: 'test' }
-    } as unknown as Request<never, never, HousingProjectSearchParameters | undefined, never>;
+    } as unknown as Request<never, never, SearchHousingProjectRequest | undefined, never>;
 
     searchSpy.mockResolvedValue([TEST_HOUSING_PROJECT_1 as HousingProject]);
 
@@ -222,7 +222,7 @@ describe('searchHousingProjectsController', () => {
   it('coerces includeUser query parameter to boolean', async () => {
     const req = {
       body: { includeUser: 'true' }
-    } as unknown as Request<never, never, HousingProjectSearchParameters | undefined, never>;
+    } as unknown as Request<never, never, SearchHousingProjectRequest | undefined, never>;
 
     searchSpy.mockResolvedValue([TEST_HOUSING_PROJECT_1 as HousingProject]);
 

--- a/app/tests/unit/controllers/housingProject.test.ts
+++ b/app/tests/unit/controllers/housingProject.test.ts
@@ -200,7 +200,7 @@ describe('searchHousingProjectsController', () => {
   it('calls the service with search params and context then responds 200', async () => {
     const req = {
       body: { projectName: 'test' }
-    } as unknown as Request<never, never, SearchHousingProjectRequest | undefined, never>;
+    } as unknown as Request<never, never, SearchHousingProjectRequest, never>;
 
     searchSpy.mockResolvedValue([TEST_HOUSING_PROJECT_1 as HousingProject]);
 
@@ -222,7 +222,7 @@ describe('searchHousingProjectsController', () => {
   it('coerces includeUser query parameter to boolean', async () => {
     const req = {
       body: { includeUser: 'true' }
-    } as unknown as Request<never, never, SearchHousingProjectRequest | undefined, never>;
+    } as unknown as Request<never, never, SearchHousingProjectRequest, never>;
 
     searchSpy.mockResolvedValue([TEST_HOUSING_PROJECT_1 as HousingProject]);
 

--- a/app/tests/unit/controllers/housingProject.test.ts
+++ b/app/tests/unit/controllers/housingProject.test.ts
@@ -16,9 +16,9 @@ import {
   getHousingProjectStatisticsController,
   listHousingProjectActivityIdsController,
   listHousingProjectsController,
+  patchHousingProjectController,
   searchHousingProjectsController,
   submitHousingProjectDraftController,
-  updateHousingProjectController,
   upsertHousingProjectDraftController
 } from '../../../src/controllers/housingProject.ts';
 import * as activityService from '../../../src/services/activity.ts';
@@ -27,7 +27,6 @@ import * as housingProjectService from '../../../src/services/housingProject.ts'
 import { Initiative } from '../../../src/utils/enums/application.ts';
 import { DraftCode } from '../../../src/utils/enums/projectCommon.ts';
 
-import type { Prisma } from '@prisma/client';
 import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
 import type {
@@ -37,6 +36,7 @@ import type {
   HousingProjectSearchParameters,
   HousingProjectStatistics,
   LocalContext,
+  PatchHousingProjectRequest,
   StatisticsFilters
 } from '../../../src/types/index.ts';
 
@@ -238,27 +238,27 @@ describe('searchHousingProjectsController', () => {
   });
 });
 
-describe('updateHousingProjectController', () => {
-  const updateSpy = vi.spyOn(housingProjectService, 'updateHousingProjectService');
+describe('patchHousingProjectController', () => {
+  const updateSpy = vi.spyOn(housingProjectService, 'patchHousingProjectService');
 
   it('calls the service with update data and projectId then responds 200', async () => {
     const updateData = { projectName: 'Updated Name' };
     const req = {
       params: { housingProjectId: '5183f223-526a-44cf-8b6a-80f90c4e802b' },
       body: updateData
-    } as unknown as Request<{ housingProjectId: string }, never, Prisma.housing_projectUpdateInput>;
+    } as unknown as Request<{ housingProjectId: string }, never, PatchHousingProjectRequest>;
 
     updateSpy.mockResolvedValue(TEST_HOUSING_PROJECT_1 as HousingProject);
 
-    await updateHousingProjectController(req, res as unknown as Response);
+    await patchHousingProjectController(req, res as unknown as Response);
 
     expect(updateSpy).toHaveBeenCalledTimes(1);
     expect(updateSpy).toHaveBeenCalledWith(
+      req.params.housingProjectId,
       expect.objectContaining({
         projectName: 'Updated Name',
         financiallySupported: expect.any(Boolean)
-      }),
-      req.params.housingProjectId
+      })
     );
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(TEST_HOUSING_PROJECT_1);

--- a/app/tests/unit/controllers/noteHistory.test.ts
+++ b/app/tests/unit/controllers/noteHistory.test.ts
@@ -4,7 +4,7 @@ import {
   deleteNoteHistoryController,
   listBringForwardsController,
   listNoteHistoriesController,
-  updateNoteHistoryController
+  patchNoteHistoryController
 } from '../../../src/controllers/noteHistory.ts';
 import * as noteHistoryService from '../../../src/services/noteHistory.ts';
 import { Resource } from '../../../src/utils/enums/application.ts';
@@ -12,7 +12,7 @@ import { BringForwardType } from '../../../src/utils/enums/projectCommon.ts';
 
 import type { Request, Response } from 'express';
 import type { Mock } from 'vitest';
-import type { LocalContext, NoteHistory } from '../../../src/types/index.ts';
+import type { LocalContext, NoteHistory, PatchNoteHistoryRequest } from '../../../src/types/index.ts';
 
 vi.mock('config');
 
@@ -113,34 +113,33 @@ describe('listNoteHistoriesController', () => {
   });
 });
 
-describe('updateNoteHistoryController', () => {
-  const updateSpy = vi.spyOn(noteHistoryService, 'updateNoteHistoryService');
+describe('patchNoteHistoryController', () => {
+  const patchSpy = vi.spyOn(noteHistoryService, 'patchNoteHistoryService');
 
-  it('calls the service with history data and note then responds 200', async () => {
+  it('calls the service with id, patch data, note, and resource then responds 200', async () => {
+    const body = {
+      ...TEST_NOTE_HISTORY_1,
+      note: 'updated note',
+      resource: Resource.ENQUIRY
+    };
+    const { note, resource, ...historyData } = body;
     const req = {
       params: { noteHistoryId: 'nh-123' },
-      body: {
-        ...TEST_NOTE_HISTORY_1,
-        note: 'updated note',
-        resource: Resource.ENQUIRY
-      }
-    } as unknown as Request<
-      { noteHistoryId: string },
-      never,
-      NoteHistory & { note: string | undefined; resource: Resource }
-    >;
+      body
+    } as unknown as Request<{ noteHistoryId: string }, never, PatchNoteHistoryRequest>;
 
-    updateSpy.mockResolvedValue(TEST_NOTE_HISTORY_1);
+    patchSpy.mockResolvedValue(TEST_NOTE_HISTORY_1);
 
-    await updateNoteHistoryController(req, res as unknown as Response<unknown, LocalContext>);
+    await patchNoteHistoryController(req, res as unknown as Response<unknown, LocalContext>);
 
-    expect(updateSpy).toHaveBeenCalledTimes(1);
-    expect(updateSpy).toHaveBeenCalledWith(
+    expect(patchSpy).toHaveBeenCalledTimes(1);
+    expect(patchSpy).toHaveBeenCalledWith(
+      'nh-123',
       TEST_CURRENT_AUTH_CONTEXT_NAVIGATOR,
       TEST_CURRENT_CONTEXT,
-      expect.objectContaining({ noteHistoryId: 'nh-123' }),
-      'updated note',
-      Resource.ENQUIRY
+      historyData,
+      note,
+      resource
     );
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(TEST_NOTE_HISTORY_1);

--- a/app/tests/unit/services/electrificationProject.test.ts
+++ b/app/tests/unit/services/electrificationProject.test.ts
@@ -266,21 +266,24 @@ describe('electrificationProject service', () => {
     });
   });
 
-  describe('updateElectrificationProjectService', () => {
+  describe('patchElectrificationProjectService', () => {
     it('updates project and returns refetched project', async () => {
-      const updateData = { submittedAt: new Date() };
+      const updateData = {
+        electrificationProjectId: TEST_ELECTRIFICATION_PROJECT_1.electrificationProjectId,
+        submittedAt: new Date()
+      };
       mockRepos.electrificationProject.update.mockResolvedValueOnce({} as never);
       mockRepos.electrificationProject.findFirstOrThrow.mockResolvedValueOnce(TEST_ELECTRIFICATION_PROJECT_1 as never);
 
-      const response = await electrificationProjectService.updateElectrificationProjectService(
-        updateData,
-        TEST_ELECTRIFICATION_PROJECT_1.electrificationProjectId
+      const response = await electrificationProjectService.patchElectrificationProjectService(
+        TEST_ELECTRIFICATION_PROJECT_1.electrificationProjectId,
+        updateData
       );
 
       expect(mockRepos.electrificationProject.update).toHaveBeenCalledTimes(1);
       expect(mockRepos.electrificationProject.update).toHaveBeenCalledWith(
         { electrificationProjectId: TEST_ELECTRIFICATION_PROJECT_1.electrificationProjectId },
-        updateData
+        { submittedAt: updateData.submittedAt }
       );
       expect(mockRepos.electrificationProject.findFirstOrThrow).toHaveBeenCalledTimes(1);
       expect(mockRepos.electrificationProject.findFirstOrThrow).toHaveBeenCalledWith({

--- a/app/tests/unit/services/electrificationProject.test.ts
+++ b/app/tests/unit/services/electrificationProject.test.ts
@@ -269,7 +269,6 @@ describe('electrificationProject service', () => {
   describe('patchElectrificationProjectService', () => {
     it('updates project and returns refetched project', async () => {
       const updateData = {
-        electrificationProjectId: TEST_ELECTRIFICATION_PROJECT_1.electrificationProjectId,
         submittedAt: new Date()
       };
       mockRepos.electrificationProject.update.mockResolvedValueOnce({} as never);

--- a/app/tests/unit/services/enquiry.test.ts
+++ b/app/tests/unit/services/enquiry.test.ts
@@ -15,8 +15,8 @@ import {
   getEnquiryService,
   listEnquiriesService,
   listRelatedEnquiriesService,
-  searchEnquiriesService,
-  updateEnquiryService
+  patchEnquiryService,
+  searchEnquiriesService
 } from '../../../src/services/enquiry.ts';
 import { Initiative } from '../../../src/utils/enums/application.ts';
 import { ActivityContactRole, EnquirySubmittedMethod } from '../../../src/utils/enums/projectCommon.ts';
@@ -241,16 +241,19 @@ describe('enquiry service', () => {
     });
   });
 
-  describe('updateEnquiryService', () => {
+  describe('patchEnquiryService', () => {
     it('updates the enquiry then returns the refreshed record', async () => {
-      const data = { enquiryDescription: 'Updated description' };
+      const data = { enquiryId: TEST_ENQUIRY_1.enquiryId, enquiryDescription: 'Updated description' };
       mockRepos.enquiry.update.mockResolvedValue(TEST_ENQUIRY_1 as never);
       mockRepos.enquiry.findFirstOrThrow.mockResolvedValue(TEST_ENQUIRY_1 as never);
 
-      const result = await updateEnquiryService(data, TEST_ENQUIRY_1.enquiryId);
+      const result = await patchEnquiryService(TEST_ENQUIRY_1.enquiryId, data);
 
       expect(mockRepos.enquiry.update).toHaveBeenCalledTimes(1);
-      expect(mockRepos.enquiry.update).toHaveBeenCalledWith({ enquiryId: TEST_ENQUIRY_1.enquiryId }, data);
+      expect(mockRepos.enquiry.update).toHaveBeenCalledWith(
+        { enquiryId: TEST_ENQUIRY_1.enquiryId },
+        { enquiryDescription: 'Updated description' }
+      );
       expect(mockRepos.enquiry.findFirstOrThrow).toHaveBeenCalledTimes(1);
       expect(mockRepos.enquiry.findFirstOrThrow).toHaveBeenCalledWith({
         where: { enquiryId: TEST_ENQUIRY_1.enquiryId },

--- a/app/tests/unit/services/enquiry.test.ts
+++ b/app/tests/unit/services/enquiry.test.ts
@@ -21,7 +21,7 @@ import {
 import { Initiative } from '../../../src/utils/enums/application.ts';
 import { ActivityContactRole, EnquirySubmittedMethod } from '../../../src/utils/enums/projectCommon.ts';
 
-import type { EnquirySearchParameters } from '../../../src/types/index.ts';
+import type { SearchEnquiriesRequest } from '../../../src/types/index.ts';
 
 vi.mock('config');
 
@@ -217,7 +217,7 @@ describe('enquiry service', () => {
 
   describe('searchEnquiriesService', () => {
     it('searches enquiries via the repository and filters by scope', async () => {
-      const params: EnquirySearchParameters = { enquiryId: [TEST_ENQUIRY_1.enquiryId], includeUser: true };
+      const params: SearchEnquiriesRequest = { enquiryId: [TEST_ENQUIRY_1.enquiryId], includeUser: true };
       const enquiries = [TEST_ENQUIRY_1];
       mockRepos.enquiry.search.mockResolvedValue(enquiries as never);
       filterSpy.mockResolvedValue(enquiries as never);
@@ -243,7 +243,7 @@ describe('enquiry service', () => {
 
   describe('patchEnquiryService', () => {
     it('updates the enquiry then returns the refreshed record', async () => {
-      const data = { enquiryId: TEST_ENQUIRY_1.enquiryId, enquiryDescription: 'Updated description' };
+      const data = { enquiryDescription: 'Updated description' };
       mockRepos.enquiry.update.mockResolvedValue(TEST_ENQUIRY_1 as never);
       mockRepos.enquiry.findFirstOrThrow.mockResolvedValue(TEST_ENQUIRY_1 as never);
 

--- a/app/tests/unit/services/generalProject.test.ts
+++ b/app/tests/unit/services/generalProject.test.ts
@@ -296,19 +296,19 @@ describe('generalProject service', () => {
     });
   });
 
-  describe('updateGeneralProjectService', () => {
+  describe('patchGeneralProjectService', () => {
     it('updates project and returns refetched project', async () => {
-      const updateData = { submittedAt: new Date() };
-      mockRepos.generalProject.update.mockResolvedValueOnce({} as never);
+      const updateData = { generalProjectId: TEST_GENERAL_PROJECT_1.generalProjectId, submittedAt: new Date() };
+      mockRepos.generalProject.patch.mockResolvedValueOnce({} as never);
       mockRepos.generalProject.findFirstOrThrow.mockResolvedValueOnce(TEST_GENERAL_PROJECT_1 as never);
 
-      const response = await generalProjectService.updateGeneralProjectService(
-        updateData,
-        TEST_GENERAL_PROJECT_1.generalProjectId
+      const response = await generalProjectService.patchGeneralProjectService(
+        TEST_GENERAL_PROJECT_1.generalProjectId,
+        updateData
       );
 
-      expect(mockRepos.generalProject.update).toHaveBeenCalledTimes(1);
-      expect(mockRepos.generalProject.update).toHaveBeenCalledWith(
+      expect(mockRepos.generalProject.patch).toHaveBeenCalledTimes(1);
+      expect(mockRepos.generalProject.patch).toHaveBeenCalledWith(
         { generalProjectId: TEST_GENERAL_PROJECT_1.generalProjectId },
         updateData
       );

--- a/app/tests/unit/services/housingProject.test.ts
+++ b/app/tests/unit/services/housingProject.test.ts
@@ -299,6 +299,7 @@ describe('housingProject service', () => {
   describe('patchHousingProjectService', () => {
     it('updates project and returns refetched project', async () => {
       const updateData = { housingProjectId: TEST_HOUSING_PROJECT_1.housingProjectId, submittedAt: new Date() };
+      mockRepos.housingProject.findFirstOrThrow.mockResolvedValueOnce(TEST_HOUSING_PROJECT_1 as never);
       mockRepos.housingProject.patch.mockResolvedValueOnce({} as never);
       mockRepos.housingProject.findFirstOrThrow.mockResolvedValueOnce(TEST_HOUSING_PROJECT_1 as never);
 
@@ -310,10 +311,10 @@ describe('housingProject service', () => {
       expect(mockRepos.housingProject.patch).toHaveBeenCalledTimes(1);
       expect(mockRepos.housingProject.patch).toHaveBeenCalledWith(
         { housingProjectId: TEST_HOUSING_PROJECT_1.housingProjectId },
-        updateData
+        { ...updateData, financiallySupported: expect.any(Boolean) }
       );
-      expect(mockRepos.housingProject.findFirstOrThrow).toHaveBeenCalledTimes(1);
-      expect(mockRepos.housingProject.findFirstOrThrow).toHaveBeenCalledWith({
+      expect(mockRepos.housingProject.findFirstOrThrow).toHaveBeenCalledTimes(2);
+      expect(mockRepos.housingProject.findFirstOrThrow).toHaveBeenLastCalledWith({
         where: {
           housingProjectId: TEST_HOUSING_PROJECT_1.housingProjectId
         },

--- a/app/tests/unit/services/housingProject.test.ts
+++ b/app/tests/unit/services/housingProject.test.ts
@@ -296,19 +296,19 @@ describe('housingProject service', () => {
     });
   });
 
-  describe('updateHousingProjectService', () => {
+  describe('patchHousingProjectService', () => {
     it('updates project and returns refetched project', async () => {
-      const updateData = { submittedAt: new Date() };
-      mockRepos.housingProject.update.mockResolvedValueOnce({} as never);
+      const updateData = { housingProjectId: TEST_HOUSING_PROJECT_1.housingProjectId, submittedAt: new Date() };
+      mockRepos.housingProject.patch.mockResolvedValueOnce({} as never);
       mockRepos.housingProject.findFirstOrThrow.mockResolvedValueOnce(TEST_HOUSING_PROJECT_1 as never);
 
-      const response = await housingProjectService.updateHousingProjectService(
-        updateData,
-        TEST_HOUSING_PROJECT_1.housingProjectId
+      const response = await housingProjectService.patchHousingProjectService(
+        TEST_HOUSING_PROJECT_1.housingProjectId,
+        updateData
       );
 
-      expect(mockRepos.housingProject.update).toHaveBeenCalledTimes(1);
-      expect(mockRepos.housingProject.update).toHaveBeenCalledWith(
+      expect(mockRepos.housingProject.patch).toHaveBeenCalledTimes(1);
+      expect(mockRepos.housingProject.patch).toHaveBeenCalledWith(
         { housingProjectId: TEST_HOUSING_PROJECT_1.housingProjectId },
         updateData
       );

--- a/app/tests/unit/services/noteHistory.test.ts
+++ b/app/tests/unit/services/noteHistory.test.ts
@@ -159,7 +159,7 @@ describe('noteHistory service', () => {
     });
   });
 
-  describe('updateNoteHistoryService', () => {
+  describe('patchNoteHistoryService', () => {
     it('updates noteHistory, creates note if provided, returns updated record', async () => {
       const noteStr = 'Updated note content';
       const updatedData = { ...TEST_NOTE_HISTORY_1, title: 'Updated Title' };
@@ -168,7 +168,8 @@ describe('noteHistory service', () => {
       mockRepos.noteHistory.findFirstOrThrow.mockResolvedValueOnce(updatedData as never);
       emailBringForwardNotificationSpy.mockResolvedValueOnce(undefined as never);
 
-      const response = await noteHistoryService.updateNoteHistoryService(
+      const response = await noteHistoryService.patchNoteHistoryService(
+        updatedData.noteHistoryId,
         TEST_CURRENT_AUTH_CONTEXT_NAVIGATOR,
         TEST_CURRENT_CONTEXT,
         updatedData,
@@ -197,7 +198,8 @@ describe('noteHistory service', () => {
       mockRepos.noteHistory.findFirstOrThrow.mockResolvedValueOnce(updatedData as never);
       emailBringForwardNotificationSpy.mockResolvedValueOnce(undefined as never);
 
-      await noteHistoryService.updateNoteHistoryService(
+      await noteHistoryService.patchNoteHistoryService(
+        updatedData.noteHistoryId,
         TEST_CURRENT_AUTH_CONTEXT_NAVIGATOR,
         TEST_CURRENT_CONTEXT,
         updatedData,
@@ -238,7 +240,8 @@ describe('noteHistory service', () => {
         ]
       };
 
-      await noteHistoryService.updateNoteHistoryService(
+      await noteHistoryService.patchNoteHistoryService(
+        updatedData.noteHistoryId,
         adminAuthContext,
         TEST_CURRENT_CONTEXT,
         updatedData,

--- a/app/tests/unit/validators/electrificationProject.test.ts
+++ b/app/tests/unit/validators/electrificationProject.test.ts
@@ -1,0 +1,52 @@
+import express from 'express';
+import request from 'supertest';
+
+import { electrificationProjectValidator } from '../../../src/validators/index.ts';
+
+import type { NextFunction, Request, Response } from 'express';
+import type Problem from '../../../src/utils/problem.ts';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.patch(
+    '/:electrificationProjectId',
+    electrificationProjectValidator.patchElectrificationProject,
+    (req: Request, res: Response) => res.status(200).json(req.body)
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use((err: Problem, req: Request, res: Response, next: NextFunction) => {
+    res.status(err.status || 500).json({ detail: err.detail });
+  });
+
+  return app;
+}
+
+const validParams = '/5183f223-526a-44cf-8b6a-80f90c4e802b';
+
+describe('patchElectrificationProject validator', () => {
+  const app = buildApp();
+
+  it('passes with an empty body', async () => {
+    const res = await request(app).patch(validParams).send({});
+    expect(res.status).toBe(200);
+  });
+
+  it('passes with a single partial field', async () => {
+    const res = await request(app).patch(validParams).send({ projectName: 'Updated Name' });
+    expect(res.status).toBe(200);
+  });
+
+  it('passes without addedToAts (optional)', async () => {
+    const res = await request(app).patch(validParams).send({ queuePriority: 1 });
+    expect(res.status).toBe(200);
+  });
+
+  it('still requires projectDescription when projectType is OTHER', async () => {
+    const res = await request(app).patch(validParams).send({ projectType: 'OTHER' });
+    expect(res.status).toBe(422);
+    expect(res.body.detail).toMatch(/"projectDescription" is required/);
+  });
+});

--- a/app/tests/unit/validators/enquiry.test.ts
+++ b/app/tests/unit/validators/enquiry.test.ts
@@ -1,0 +1,49 @@
+import express from 'express';
+import request from 'supertest';
+
+import { enquiryValidator } from '../../../src/validators/index.ts';
+
+import type { NextFunction, Request, Response } from 'express';
+import type Problem from '../../../src/utils/problem.ts';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.patch('/:enquiryId', enquiryValidator.patchEnquiry, (req: Request, res: Response) =>
+    res.status(200).json(req.body)
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use((err: Problem, req: Request, res: Response, next: NextFunction) => {
+    res.status(err.status || 500).json({ detail: err.detail });
+  });
+
+  return app;
+}
+
+const validParams = '/5183f223-526a-44cf-8b6a-80f90c4e802b';
+
+describe('patchEnquiry validator', () => {
+  const app = buildApp();
+
+  it('passes with an empty body', async () => {
+    const res = await request(app).patch(validParams).send({});
+    expect(res.status).toBe(200);
+  });
+
+  it('passes with a single partial field', async () => {
+    const res = await request(app).patch(validParams).send({ enquiryDescription: 'Updated description' });
+    expect(res.status).toBe(200);
+  });
+
+  it('passes without addedToAts (optional)', async () => {
+    const res = await request(app).patch(validParams).send({ enquiryStatus: 'New' });
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts addedToAts as a boolean when supplied', async () => {
+    const res = await request(app).patch(validParams).send({ addedToAts: true });
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/tests/unit/validators/generalProject.test.ts
+++ b/app/tests/unit/validators/generalProject.test.ts
@@ -1,0 +1,55 @@
+import express from 'express';
+import request from 'supertest';
+
+import { generalProjectValidator } from '../../../src/validators/index.ts';
+
+import type { NextFunction, Request, Response } from 'express';
+import type Problem from '../../../src/utils/problem.ts';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.patch('/:generalProjectId', generalProjectValidator.patchGeneralProject, (req: Request, res: Response) =>
+    res.status(200).json(req.body)
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use((err: Problem, req: Request, res: Response, next: NextFunction) => {
+    res.status(err.status || 500).json({ detail: err.detail });
+  });
+
+  return app;
+}
+
+const validParams = '/5183f223-526a-44cf-8b6a-80f90c4e802b';
+
+describe('patchGeneralProject validator', () => {
+  const app = buildApp();
+
+  it('passes with an empty body', async () => {
+    const res = await request(app).patch(validParams).send({});
+    expect(res.status).toBe(200);
+  });
+
+  it('passes with a single partial field', async () => {
+    const res = await request(app).patch(validParams).send({ projectName: 'Updated Name' });
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts naturalDisaster as a boolean', async () => {
+    const res = await request(app).patch(validParams).send({ naturalDisaster: true });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects addedToAts, which does not exist on general_project', async () => {
+    const res = await request(app).patch(validParams).send({ addedToAts: true });
+    expect(res.status).toBe(422);
+    expect(res.body.detail).toMatch(/"addedToAts" is not allowed/);
+  });
+
+  it('passes with atsClientId and atsEnquiryId', async () => {
+    const res = await request(app).patch(validParams).send({ atsClientId: 1, atsEnquiryId: 2 });
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/tests/unit/validators/housingProject.test.ts
+++ b/app/tests/unit/validators/housingProject.test.ts
@@ -1,0 +1,63 @@
+import express from 'express';
+import request from 'supertest';
+
+import { housingProjectValidator } from '../../../src/validators/index.ts';
+
+import type { NextFunction, Request, Response } from 'express';
+import type Problem from '../../../src/utils/problem.ts';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.patch('/:housingProjectId', housingProjectValidator.patchHousingProject, (req: Request, res: Response) =>
+    res.status(200).json(req.body)
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use((err: Problem, req: Request, res: Response, next: NextFunction) => {
+    res.status(err.status || 500).json({ detail: err.detail });
+  });
+
+  return app;
+}
+
+const validParams = '/5183f223-526a-44cf-8b6a-80f90c4e802b';
+
+describe('patchHousingProject validator', () => {
+  const app = buildApp();
+
+  it('passes with an empty body', async () => {
+    const res = await request(app).patch(validParams).send({});
+    expect(res.status).toBe(200);
+  });
+
+  it('passes with a single partial field', async () => {
+    const res = await request(app).patch(validParams).send({ projectName: 'Updated Name' });
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts naturalDisaster as a boolean', async () => {
+    const res = await request(app).patch(validParams).send({ naturalDisaster: true });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects naturalDisaster as a string', async () => {
+    const res = await request(app).patch(validParams).send({ naturalDisaster: 'No' });
+    expect(res.status).toBe(422);
+  });
+
+  it('still enforces otherUnits when otherUnitsDescription is Yes', async () => {
+    const res = await request(app).patch(validParams).send({ otherUnitsDescription: 'Yes' });
+    expect(res.status).toBe(422);
+    expect(res.body.detail).toMatch(/"otherUnits" is required/);
+  });
+
+  it('rejects fields not in the patchable schema', async () => {
+    const res = await request(app)
+      .patch(validParams)
+      .send({ geoJson: { type: 'Point' } });
+    expect(res.status).toBe(422);
+    expect(res.body.detail).toMatch(/"geoJson" is not allowed/);
+  });
+});

--- a/frontend/src/components/authorization/AuthorizationForm.vue
+++ b/frontend/src/components/authorization/AuthorizationForm.vue
@@ -408,7 +408,7 @@ onBeforeMount(async () => {
   const response: SourceSystemKind[] = await sourceSystemKindService.listSourceSystemKinds();
   sourceSystemKinds.value = response.sort(sortForDisplayOrder);
   if (authorization?.updatedBy) {
-    updatedBy.value = (await userService.listUsers({ userId: [authorization?.updatedBy] }))[0];
+    updatedBy.value = (await userService.searchUsers({ userId: [authorization?.updatedBy] }))[0];
   }
 });
 

--- a/frontend/src/components/contact/ContactForm.vue
+++ b/frontend/src/components/contact/ContactForm.vue
@@ -11,7 +11,7 @@ import { setEmptyStringsToNull } from '@/utils/utils';
 import { contactSchema } from '@/validators/contact';
 
 import type { GenericObject } from 'vee-validate';
-import type { Contact, PutContactRequest } from '@/types';
+import type { Contact, UpsertContactRequest } from '@/types';
 
 // Props
 const { contact, editable } = defineProps<{
@@ -43,8 +43,8 @@ const initialFormValues = ref({
 // Actions
 const onSubmit = async (values: GenericObject) => {
   try {
-    const req: PutContactRequest = setEmptyStringsToNull(values);
-    const result = await contactService.putContact(req);
+    const req: UpsertContactRequest = setEmptyStringsToNull(values);
+    const result = await contactService.upsertContact(req);
 
     formRef.value?.resetForm({
       values: {

--- a/frontend/src/components/contact/ContactPage.vue
+++ b/frontend/src/components/contact/ContactPage.vue
@@ -101,7 +101,7 @@ onBeforeMount(async () => {
   if (userIds) {
     const idpCfg = findIdpConfig(IdentityProviderKind.AZUREIDIR);
     if (idpCfg) {
-      const users = await userService.listUsers({ userId: userIds, idp: [idpCfg.idp] });
+      const users = await userService.searchUsers({ userId: userIds, idp: [idpCfg.idp] });
       users.forEach((u: User) => {
         assignedUsers.value[u.userId] = u.fullName;
       });

--- a/frontend/src/components/electrification/project/ProjectFormNavigator.vue
+++ b/frontend/src/components/electrification/project/ProjectFormNavigator.vue
@@ -105,7 +105,7 @@ const projectFormNavigatorSchema = computed(() => {
 // Actions
 async function initializeFormValues(project: ElectrificationProject): Promise<DeepPartial<FormSchemaType>> {
   let assigneeOptions: User[] = [];
-  if (project.assignedUserId) assigneeOptions = await userService.listUsers({ userId: [project.assignedUserId] });
+  if (project.assignedUserId) assigneeOptions = await userService.searchUsers({ userId: [project.assignedUserId] });
 
   return {
     contact: {

--- a/frontend/src/components/enquiry/EnquiryCard.vue
+++ b/frontend/src/components/enquiry/EnquiryCard.vue
@@ -24,7 +24,7 @@ const userName: Ref<string> = ref('');
 // Actions
 onBeforeMount(() => {
   if (enquiry.createdBy) {
-    userService.listUsers({ userId: [enquiry.createdBy] }).then((res) => {
+    userService.searchUsers({ userId: [enquiry.createdBy] }).then((res) => {
       userName.value = res?.length ? res?.[0].fullName : '';
     });
   }

--- a/frontend/src/components/enquiry/EnquiryForm.vue
+++ b/frontend/src/components/enquiry/EnquiryForm.vue
@@ -177,7 +177,7 @@ async function getRelatedATSClientID(activityId: string) {
 async function initializeFormValues(): Promise<DeepPartial<FormSchemaType>> {
   let assigneeOptions: User[] = [];
   if (enquiry?.assignedUserId) {
-    assigneeOptions = await userService.listUsers({ userId: [enquiry.assignedUserId] });
+    assigneeOptions = await userService.searchUsers({ userId: [enquiry.assignedUserId] });
   }
 
   let atsClientId;

--- a/frontend/src/components/general/project/ProjectFormNavigator.vue
+++ b/frontend/src/components/general/project/ProjectFormNavigator.vue
@@ -80,7 +80,7 @@ const showCancelMessage: Ref<boolean> = ref(false);
 // Actions
 async function initializeFormValues(project: GeneralProject): Promise<DeepPartial<FormSchemaType>> {
   let assigneeOptions: User[] = [];
-  if (project.assignedUserId) assigneeOptions = await userService.listUsers({ userId: [project.assignedUserId] });
+  if (project.assignedUserId) assigneeOptions = await userService.searchUsers({ userId: [project.assignedUserId] });
 
   return {
     contact: {

--- a/frontend/src/components/housing/project/ProjectFormNavigator.vue
+++ b/frontend/src/components/housing/project/ProjectFormNavigator.vue
@@ -202,7 +202,7 @@ async function handleAtsCreate(formValues: AtsCreateResponse) {
 
 async function initializeFormValues(project: HousingProject): Promise<DeepPartial<FormSchemaType>> {
   let assigneeOptions: User[] = [];
-  if (project.assignedUserId) assigneeOptions = await userService.listUsers({ userId: [project.assignedUserId] });
+  if (project.assignedUserId) assigneeOptions = await userService.searchUsers({ userId: [project.assignedUserId] });
 
   return {
     contact: {

--- a/frontend/src/components/note/NoteForm.vue
+++ b/frontend/src/components/note/NoteForm.vue
@@ -180,7 +180,7 @@ async function onSubmit(data: GenericObject) {
       });
     } else {
       if (!resource?.value) throw new Error(t('note.noteForm.resourceNotDef'));
-      await noteHistoryService.putNoteHistory({
+      await noteHistoryService.patchNoteHistory({
         ...body,
         activityId,
         note: data.note,

--- a/frontend/src/components/note/NoteForm.vue
+++ b/frontend/src/components/note/NoteForm.vue
@@ -54,7 +54,6 @@ const { options } = useCodeStore();
 
 // Form Schema
 const formSchema = object({
-  activityId: string(),
   bringForwardDate: mixed()
     .nullable()
     .when('type', {
@@ -107,7 +106,6 @@ const shownToProponent: Ref<boolean> = ref(false);
 function initializeFormValues() {
   if (noteHistory) {
     initialFormValues.value = {
-      activityId: noteHistory.activityId,
       bringForwardDate: noteHistory?.bringForwardDate ? new Date(noteHistory.bringForwardDate) : null,
       bringForwardState: noteHistory?.bringForwardState ?? undefined,
       escalateToSupervisor: noteHistory?.escalateToSupervisor,
@@ -182,7 +180,6 @@ async function onSubmit(data: GenericObject) {
       if (!resource?.value) throw new Error(t('note.noteForm.resourceNotDef'));
       await noteHistoryService.patchNoteHistory({
         ...body,
-        activityId,
         note: data.note,
         resource: resource.value
       });
@@ -203,7 +200,7 @@ function onTypeChange(e: SelectChangeEvent) {
 
 async function fetchCreatedBy() {
   const userIds = Array.from(new Set(noteHistory?.note?.map((n) => n.createdBy).filter(Boolean))) as [];
-  const users = await userService.listUsers({ userId: userIds });
+  const users = await userService.searchUsers({ userId: userIds });
   users.forEach((u: User) => {
     createdByFullNames.value[u.userId] = u.fullName;
   });

--- a/frontend/src/components/note/NoteHistoryCard.vue
+++ b/frontend/src/components/note/NoteHistoryCard.vue
@@ -44,7 +44,7 @@ const getEscalationLabel = computed(() => (type: string) => {
 
 onBeforeMount(() => {
   if (!userName.value && noteHistory.createdBy) {
-    userService.listUsers({ userId: [noteHistory.createdBy] }).then((res) => {
+    userService.searchUsers({ userId: [noteHistory.createdBy] }).then((res) => {
       userName.value = res?.length ? res?.[0].fullName : '';
     });
   }

--- a/frontend/src/components/projectCommon/ProjectRoadmapTab.vue
+++ b/frontend/src/components/projectCommon/ProjectRoadmapTab.vue
@@ -119,7 +119,7 @@ watch(
     };
 
     if (project?.assignedUserId) {
-      const assignee = (await userService.listUsers({ userId: [project.assignedUserId] }))[0];
+      const assignee = (await userService.searchUsers({ userId: [project.assignedUserId] }))[0];
 
       if (assignee) {
         navigator = assignee;

--- a/frontend/src/components/projectCommon/ProjectTeamTab.vue
+++ b/frontend/src/components/projectCommon/ProjectTeamTab.vue
@@ -136,7 +136,7 @@ async function onAddUsers(contactsAndRoles: { contact: Contact; role: ActivityCo
 
     try {
       if (!contact.contactId) {
-        contact = await contactService.putContact(contact);
+        contact = await contactService.upsertContact(contact);
       }
 
       if (!getProject.value?.activityId) throw new Error('No activity ID');

--- a/frontend/src/components/submission/SubmissionStatistics.vue
+++ b/frontend/src/components/submission/SubmissionStatistics.vue
@@ -44,9 +44,9 @@ async function onAssigneeInput(e: InputEvent) {
   const input = e.target.value;
 
   if (input.length >= MIN_SEARCH_INPUT_LENGTH) {
-    assigneeOptions.value = await userService.listUsers({ email: input, fullName: input });
+    assigneeOptions.value = await userService.searchUsers({ email: input, fullName: input });
   } else if (input.match(Regex.EMAIL)) {
-    assigneeOptions.value = await userService.listUsers({ email: input });
+    assigneeOptions.value = await userService.searchUsers({ email: input });
   } else {
     assigneeOptions.value = [];
   }

--- a/frontend/src/composables/useUserSearch.ts
+++ b/frontend/src/composables/useUserSearch.ts
@@ -16,7 +16,7 @@ export function useUserSearch() {
     const idpCfg = findIdpConfig(IdentityProviderKind.AZUREIDIR);
     if (!idpCfg) return;
 
-    users.value = await userService.listUsers({
+    users.value = await userService.searchUsers({
       userId: Array.isArray(userId) ? userId : [userId]
     });
   };
@@ -28,9 +28,9 @@ export function useUserSearch() {
 
     if (idpCfg) {
       if (input.length >= MIN_SEARCH_INPUT_LENGTH) {
-        users.value = await userService.listUsers({ email: input, fullName: input, idp: [idpCfg.idp] });
+        users.value = await userService.searchUsers({ email: input, fullName: input, idp: [idpCfg.idp] });
       } else if (EMAILREGEX.test(input)) {
-        users.value = await userService.listUsers({ email: input, idp: [idpCfg.idp] });
+        users.value = await userService.searchUsers({ email: input, idp: [idpCfg.idp] });
       } else {
         users.value = [];
       }

--- a/frontend/src/services/contactService.ts
+++ b/frontend/src/services/contactService.ts
@@ -1,7 +1,13 @@
 import { api } from './apiClient';
 import { createRouteBuilder } from './routeBuilder';
 
-import type { Contact, DeleteContactRequest, GetContactRequest, ListContactsRequest, PutContactRequest } from '@/types';
+import type {
+  Contact,
+  DeleteContactRequest,
+  GetContactRequest,
+  ListContactsRequest,
+  UpsertContactRequest
+} from '@/types';
 
 /**
  * Base route builder and endpoint definitions for this resource.
@@ -69,12 +75,12 @@ export function searchContacts(req: ListContactsRequest): Promise<Contact[]> {
 }
 
 /**
- * Updates the current contact.
- * @param req - The request payload containing updated contact data.
- * @returns A promise resolving to the updated `Contact` resource.
+ * Creates or updates a contact.
+ * @param req - The request payload containing the contact data.
+ * @returns A promise resolving to the saved `Contact` resource.
  */
-export function putContact(req: PutContactRequest): Promise<Contact> {
-  return api.put<Contact>(contactRoutes.root(), req);
+export function upsertContact(req: UpsertContactRequest): Promise<Contact> {
+  return api.post<Contact>(contactRoutes.root(), req);
 }
 
 /**
@@ -91,5 +97,5 @@ export const contactService = {
   deleteContact,
   matchContacts,
   searchContacts,
-  putContact
+  upsertContact
 };

--- a/frontend/src/services/electrificationProjectService.ts
+++ b/frontend/src/services/electrificationProjectService.ts
@@ -160,7 +160,7 @@ export async function searchProjects(req: ListElectrificationProjectsRequest): P
 export async function submitDraft(req: SubmitDraftElectrificationProjectRequest): Promise<ElectrificationProject> {
   const { ...body } = req;
 
-  return api.put<ElectrificationProject>(electrificationProjectRoutes.submitDraft(), body);
+  return api.post<ElectrificationProject>(electrificationProjectRoutes.submitDraft(), body);
 }
 
 /**
@@ -171,7 +171,7 @@ export async function submitDraft(req: SubmitDraftElectrificationProjectRequest)
 export async function upsertDraft(req: UpsertDraftRequest): Promise<Draft<FormSchemaType>> {
   const { ...body } = req;
 
-  return api.put<Draft<FormSchemaType>>(electrificationProjectRoutes.draft(), body);
+  return api.post<Draft<FormSchemaType>>(electrificationProjectRoutes.draft(), body);
 }
 
 /**

--- a/frontend/src/services/electrificationProjectService.ts
+++ b/frontend/src/services/electrificationProjectService.ts
@@ -14,7 +14,7 @@ import type {
   GetProjectStatisticsRequest,
   PatchElectrificationProjectRequest,
   ProjectStatistics,
-  ListElectrificationProjectsRequest,
+  SearchElectrificationProjectRequest,
   UpsertDraftRequest,
   SubmitDraftElectrificationProjectRequest
 } from '@/types';
@@ -148,7 +148,7 @@ export async function patchProject(req: PatchElectrificationProjectRequest): Pro
  * @param req - The request payload containing optional search criteria.
  * @returns A promise resolving to an array of `ElectrificationProject` resources.
  */
-export async function searchProjects(req: ListElectrificationProjectsRequest): Promise<ElectrificationProject[]> {
+export async function searchProjects(req: SearchElectrificationProjectRequest): Promise<ElectrificationProject[]> {
   return api.post<ElectrificationProject[]>(electrificationProjectRoutes.search(), req);
 }
 
@@ -187,7 +187,7 @@ export interface ElectrificationProjectService extends DraftableProjectService<E
   getProject(req: GetProjectRequest): Promise<ElectrificationProject>;
   getDraft(req: GetDraftRequest): Promise<Draft<FormSchemaType>>;
   listDrafts(): Promise<Draft<FormSchemaType>[]>;
-  searchProjects(req: ListElectrificationProjectsRequest): Promise<ElectrificationProject[]>;
+  searchProjects(req: SearchElectrificationProjectRequest): Promise<ElectrificationProject[]>;
   submitDraft(req: SubmitDraftElectrificationProjectRequest): Promise<ElectrificationProject>;
   upsertDraft(req: UpsertDraftRequest): Promise<Draft<FormSchemaType>>;
 }

--- a/frontend/src/services/enquiryService.ts
+++ b/frontend/src/services/enquiryService.ts
@@ -3,6 +3,7 @@ import { createInitiativeRouteBuilder } from './routeBuilder';
 
 import type {
   CreateEnquiryRequest,
+  CreateEnquiryResponse,
   DeleteEnquiryRequest,
   Enquiry,
   GetEnquiryRequest,
@@ -31,10 +32,10 @@ const enquiryRoutes = {
  * @param req - The request payload containing the enquiry data to create.
  * @returns A promise resolving to the created `Enquiry` resource.
  */
-export function createEnquiry(req: CreateEnquiryRequest): Promise<Enquiry> {
+export function createEnquiry(req: CreateEnquiryRequest): Promise<CreateEnquiryResponse> {
   const { ...body } = req;
 
-  return api.post<Enquiry>(enquiryRoutes.root(), body);
+  return api.post<CreateEnquiryResponse>(enquiryRoutes.root(), body);
 }
 
 /**

--- a/frontend/src/services/generalProjectService.ts
+++ b/frontend/src/services/generalProjectService.ts
@@ -14,7 +14,7 @@ import type {
   GeneralProject,
   PatchGeneralProjectRequest,
   ProjectStatistics,
-  ListGeneralProjectsRequest,
+  SearchGeneralProjectRequest,
   UpsertDraftRequest,
   SubmitDraftGeneralProjectRequest
 } from '@/types';
@@ -148,7 +148,7 @@ export async function patchProject(req: PatchGeneralProjectRequest): Promise<Gen
  * @param req - The request payload containing optional search criteria.
  * @returns A promise resolving to an array of `GeneralProject` resources.
  */
-export async function searchProjects(req: ListGeneralProjectsRequest): Promise<GeneralProject[]> {
+export async function searchProjects(req: SearchGeneralProjectRequest): Promise<GeneralProject[]> {
   return api.post<GeneralProject[]>(generalProjectRoutes.search(), req);
 }
 
@@ -187,7 +187,7 @@ export interface GeneralProjectService extends DraftableProjectService<GeneralPr
   getDraft(req: GetDraftRequest): Promise<Draft<FormSchemaType>>;
   getProject(req: GetProjectRequest): Promise<GeneralProject>;
   listDrafts(): Promise<Draft<FormSchemaType>[]>;
-  searchProjects(req: ListGeneralProjectsRequest): Promise<GeneralProject[]>;
+  searchProjects(req: SearchGeneralProjectRequest): Promise<GeneralProject[]>;
   submitDraft(req: SubmitDraftGeneralProjectRequest): Promise<GeneralProject>;
   upsertDraft(req: UpsertDraftRequest): Promise<Draft<FormSchemaType>>;
 }

--- a/frontend/src/services/generalProjectService.ts
+++ b/frontend/src/services/generalProjectService.ts
@@ -160,7 +160,7 @@ export async function searchProjects(req: ListGeneralProjectsRequest): Promise<G
 export async function submitDraft(req: SubmitDraftGeneralProjectRequest): Promise<GeneralProject> {
   const { ...body } = req;
 
-  return api.put<GeneralProject>(generalProjectRoutes.submitDraft(), body);
+  return api.post<GeneralProject>(generalProjectRoutes.submitDraft(), body);
 }
 
 /**
@@ -171,7 +171,7 @@ export async function submitDraft(req: SubmitDraftGeneralProjectRequest): Promis
 export async function upsertDraft(req: UpsertDraftRequest): Promise<Draft<FormSchemaType>> {
   const { ...body } = req;
 
-  return api.put<Draft<FormSchemaType>>(generalProjectRoutes.draft(), body);
+  return api.post<Draft<FormSchemaType>>(generalProjectRoutes.draft(), body);
 }
 
 /**

--- a/frontend/src/services/housingProjectService.ts
+++ b/frontend/src/services/housingProjectService.ts
@@ -14,7 +14,7 @@ import type {
   HousingProject,
   PatchHousingProjectRequest,
   ProjectStatistics,
-  ListHousingProjectRequest,
+  SearchHousingProjectRequest,
   SubmitDraftHousingProjectRequest,
   UpsertDraftRequest
 } from '@/types';
@@ -148,7 +148,7 @@ export function patchProject(req: PatchHousingProjectRequest): Promise<HousingPr
  * @param req - The request payload containing optional search criteria.
  * @returns A promise resolving to an array of `HousingProject` resources.
  */
-export function searchProjects(req: ListHousingProjectRequest): Promise<HousingProject[]> {
+export function searchProjects(req: SearchHousingProjectRequest): Promise<HousingProject[]> {
   return api.post<HousingProject[]>(housingProjectRoutes.search(), req);
 }
 
@@ -187,7 +187,7 @@ export interface HousingProjectService extends DraftableProjectService<HousingPr
   getDraft(req: GetDraftRequest): Promise<Draft<FormSchemaType>>;
   getProject(req: GetProjectRequest): Promise<HousingProject>;
   listDrafts(): Promise<Draft<FormSchemaType>[]>;
-  searchProjects(req: ListHousingProjectRequest): Promise<HousingProject[]>;
+  searchProjects(req: SearchHousingProjectRequest): Promise<HousingProject[]>;
   submitDraft(req: SubmitDraftHousingProjectRequest): Promise<HousingProject>;
   upsertDraft(req: UpsertDraftRequest): Promise<Draft<FormSchemaType>>;
 }

--- a/frontend/src/services/housingProjectService.ts
+++ b/frontend/src/services/housingProjectService.ts
@@ -160,7 +160,7 @@ export function searchProjects(req: ListHousingProjectRequest): Promise<HousingP
 export function submitDraft(req: SubmitDraftHousingProjectRequest): Promise<HousingProject> {
   const { ...body } = req;
 
-  return api.put<HousingProject>(housingProjectRoutes.submitDraft(), body);
+  return api.post<HousingProject>(housingProjectRoutes.submitDraft(), body);
 }
 
 /**
@@ -171,7 +171,7 @@ export function submitDraft(req: SubmitDraftHousingProjectRequest): Promise<Hous
 export function upsertDraft(req: UpsertDraftRequest): Promise<Draft<FormSchemaType>> {
   const { ...body } = req;
 
-  return api.put<Draft<FormSchemaType>>(housingProjectRoutes.draft(), body);
+  return api.post<Draft<FormSchemaType>>(housingProjectRoutes.draft(), body);
 }
 
 /**

--- a/frontend/src/services/noteHistoryService.ts
+++ b/frontend/src/services/noteHistoryService.ts
@@ -8,7 +8,7 @@ import type {
   ListBringForwardsRequest,
   ListNoteHistoriesRequest,
   NoteHistory,
-  PutNoteHistoryRequest
+  PatchNoteHistoryRequest
 } from '@/types';
 /**
  * Base route builder and endpoint definitions for this resource.
@@ -70,14 +70,14 @@ export function listNoteHistories(req: ListNoteHistoriesRequest): Promise<NoteHi
 }
 
 /**
- * Updates a note history record.
- * @param req - The request payload containing the note history ID and updated fields.
+ * Patches a note history record.
+ * @param req - The request payload containing the note history ID and fields to update.
  * @returns A promise resolving to the updated `NoteHistory` resource.
  */
-export function putNoteHistory(req: PutNoteHistoryRequest): Promise<NoteHistory> {
+export function patchNoteHistory(req: PatchNoteHistoryRequest): Promise<NoteHistory> {
   const { noteHistoryId, ...body } = req;
 
-  return api.put<NoteHistory>(noteRoutes.byId(noteHistoryId), body);
+  return api.patch<NoteHistory>(noteRoutes.byId(noteHistoryId), body);
 }
 
 /**
@@ -93,5 +93,5 @@ export const noteHistoryService = {
   deleteNoteHistory,
   listBringForwards,
   listNoteHistories,
-  putNoteHistory
+  patchNoteHistory
 };

--- a/frontend/src/services/permitService.ts
+++ b/frontend/src/services/permitService.ts
@@ -86,7 +86,7 @@ export function searchPermits(req?: ListPermitsRequest): Promise<SearchPermitsRe
  * @returns A promise resolving to the saved permit.
  */
 export function upsertPermit(req: UpsertPermitRequest): Promise<Permit> {
-  return api.put<Permit>(permitRoutes.root(), req);
+  return api.post<Permit>(permitRoutes.root(), req);
 }
 
 /**

--- a/frontend/src/services/roadmapService.ts
+++ b/frontend/src/services/roadmapService.ts
@@ -54,7 +54,7 @@ export function sendRoadmap(req: SendRoadmapRequest): Promise<NoteHistory> {
     normalizedEmailData.bcc = delimitEmails(normalizedEmailData.bcc);
   }
 
-  return api.put<NoteHistory>(roadmapRoutes.root(), {
+  return api.post<NoteHistory>(roadmapRoutes.root(), {
     activityId,
     selectedFileIds,
     emailData: normalizedEmailData

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -1,7 +1,7 @@
 import { api } from './apiClient';
 import { createRouteBuilder } from './routeBuilder';
 
-import type { ListUsersRequest, User } from '@/types';
+import type { SearchUsersRequest, User } from '@/types';
 
 /**
  * Base route builder and endpoint definitions for this resource.
@@ -11,16 +11,16 @@ import type { ListUsersRequest, User } from '@/types';
 const userRoute = createRouteBuilder('user');
 
 const userRoutes = {
-  root: () => userRoute()
+  search: () => userRoute('search')
 } as const;
 
 /**
- * Lists users using the supplied filters.
+ * Searches users using the supplied filters.
  * @param req - Optional search criteria.
  * @returns A promise resolving to matching users.
  */
-export function listUsers(req: ListUsersRequest): Promise<User[]> {
-  return api.post<User[]>(userRoutes.root(), req);
+export function searchUsers(req: SearchUsersRequest): Promise<User[]> {
+  return api.post<User[]>(userRoutes.search(), req);
 }
 
 /**
@@ -32,5 +32,5 @@ export function listUsers(req: ListUsersRequest): Promise<User[]> {
  * It may be removed once all consumers are migrated to named imports.
  */
 export const userService = {
-  listUsers
+  searchUsers
 };

--- a/frontend/src/types/api/requests.ts
+++ b/frontend/src/types/api/requests.ts
@@ -107,7 +107,7 @@ interface ContactSearchSchema extends ContactBaseSchema {
 export type CreateContactRequest = CreateRequestDTO<ContactBase, ContactBaseSchema>;
 export type GetContactRequest = ListRequestDTO<ContactBase, ContactGetSchema>;
 export type ListContactsRequest = ListRequestDTO<ContactBase, ContactSearchSchema>;
-export type PutContactRequest = UpsertRequestDTO<ContactBase, ContactBaseSchema>;
+export type UpsertContactRequest = UpsertRequestDTO<ContactBase, ContactBaseSchema>;
 export type DeleteContactRequest = DeleteRequestDTO<ContactBase, ContactBaseSchema>;
 
 /**
@@ -264,8 +264,9 @@ interface NoteHistoryQuerySchema extends NoteHistoryBaseSchema {
 export type CreateNoteHistoryRequest = CreateRequestDTO<NoteHistoryBase, NoteHistoryBaseSchema> & { note: string };
 export type ListBringForwardsRequest = ListRequestDTO<NoteHistoryBase, NoteHistoryBringForwardSchema>;
 export type ListNoteHistoriesRequest = ListRequestDTO<NoteHistoryBase, NoteHistoryQuerySchema>;
-export type PutNoteHistoryRequest = PutRequestDTO<NoteHistoryBase & { resource: Resource }, NoteHistoryBaseSchema> & {
-  note: string;
+export type PatchNoteHistoryRequest = PatchRequestDTO<NoteHistoryBase, NoteHistoryBaseSchema> & {
+  note: string | undefined;
+  resource: Resource;
 };
 export type DeleteNoteHistoryRequest = DeleteRequestDTO<NoteHistoryBase, NoteHistoryBaseSchema>;
 

--- a/frontend/src/types/api/requests.ts
+++ b/frontend/src/types/api/requests.ts
@@ -14,7 +14,6 @@ import type {
   Document,
   Draft,
   ElectrificationProjectBase,
-  Enquiry,
   EnquiryBase,
   GeneralProjectBase,
   HousingProjectBase,
@@ -167,7 +166,7 @@ export type CreateElectrificationProjectRequest = CreateRequestDTO<
   Partial<ElectrificationProjectBase>,
   ElectrificationProjectBaseSchema
 >;
-export type ListElectrificationProjectsRequest = ListRequestDTO<
+export type SearchElectrificationProjectRequest = ListRequestDTO<
   Partial<ElectrificationProjectBase>,
   ElectrificationProjectBaseSchema
 >;
@@ -193,7 +192,7 @@ interface EnquirySearchSchema extends EnquiryBaseSchema {
   query: { activityId: string[]; createdBy: string[]; enquiryId: string[]; includeUser: boolean };
 }
 export type CreateEnquiryRequest = PartialFields<
-  Pick<Enquiry, 'contact' | 'enquiryDescription' | 'relatedActivityId' | 'submissionType'>,
+  Pick<EnquiryBase, 'enquiryDescription' | 'relatedActivityId' | 'submissionType'> & { contact: ContactBase },
   'submissionType'
 >;
 export type GetEnquiryRequest = GetRequestDTO<EnquiryBase, EnquiryBaseSchema>;
@@ -219,7 +218,7 @@ interface GeneralProjectBaseSchema extends ResourceSchemaConfig<GeneralProjectBa
   };
 }
 export type CreateGeneralProjectRequest = CreateRequestDTO<Partial<GeneralProjectBase>, GeneralProjectBaseSchema>;
-export type ListGeneralProjectsRequest = ListRequestDTO<Partial<GeneralProjectBase>, GeneralProjectBaseSchema>;
+export type SearchGeneralProjectRequest = ListRequestDTO<Partial<GeneralProjectBase>, GeneralProjectBaseSchema>;
 export type PatchGeneralProjectRequest = PatchRequestDTO<GeneralProjectBase, GeneralProjectBaseSchema>;
 export type SubmitDraftGeneralProjectRequest = GeneralProjectIntake;
 
@@ -240,7 +239,7 @@ interface HousingProjectBaseSchema extends ResourceSchemaConfig<HousingProjectBa
   };
 }
 export type CreateHousingProjectRequest = CreateRequestDTO<Partial<HousingProjectBase>, HousingProjectBaseSchema>;
-export type ListHousingProjectRequest = ListRequestDTO<Partial<HousingProjectBase>, HousingProjectBaseSchema>;
+export type SearchHousingProjectRequest = ListRequestDTO<Partial<HousingProjectBase>, HousingProjectBaseSchema>;
 export type PatchHousingProjectRequest = PatchRequestDTO<HousingProjectBase, HousingProjectBaseSchema>;
 export type SubmitDraftHousingProjectRequest = HousingProjectIntake;
 

--- a/frontend/src/types/api/requests.ts
+++ b/frontend/src/types/api/requests.ts
@@ -249,7 +249,7 @@ export type SubmitDraftHousingProjectRequest = HousingProjectIntake;
 
 interface NoteHistoryBaseSchema extends ResourceSchemaConfig<NoteHistoryBase> {
   ids: 'noteHistoryId';
-  immutable: 'noteHistoryId';
+  immutable: 'activityId' | 'noteHistoryId';
   serverGenerated: 'noteHistoryId';
 }
 interface NoteHistoryBringForwardSchema extends NoteHistoryBaseSchema {
@@ -326,7 +326,7 @@ export type DeleteProjectRequest = DeleteRequestDTO<ProjectBase, ProjectSchema>;
  * User
  */
 
-export interface ListUsersRequest {
+export interface SearchUsersRequest {
   userId?: string[];
   idp?: string[];
   sub?: string;

--- a/frontend/src/types/api/resources.ts
+++ b/frontend/src/types/api/resources.ts
@@ -215,7 +215,7 @@ export interface EnquiryBase extends AuditFields {
 
 interface EnquiryRelations {
   activity: Activity;
-  contact: Contact;
+  user: User;
 }
 
 export type Enquiry = EnquiryBase & Partial<EnquiryRelations>;

--- a/frontend/src/types/api/responses.ts
+++ b/frontend/src/types/api/responses.ts
@@ -1,10 +1,12 @@
 import type { BasicResponse } from '@/utils/enums/application';
-import type { ActivityContact, Group } from './resources';
+import type { ActivityContact, Contact, Enquiry, Group } from './resources';
 import type { SsoIdirUserAttributes } from '../oidc';
 import type { ContactPreference, ProjectRelationship } from '@/utils/enums/projectCommon';
 import type { CodeTableName } from '../common';
 import type { PermitStage, PermitState, PiesOnHold } from '@/utils/enums/codeEnums';
 import type { Code, Permission } from '../ui';
+
+export type CreateEnquiryResponse = Enquiry & { contact?: Contact };
 
 export interface CreateObjectResponse {
   id: string;

--- a/frontend/src/types/api/responses.ts
+++ b/frontend/src/types/api/responses.ts
@@ -6,7 +6,7 @@ import type { CodeTableName } from '../common';
 import type { PermitStage, PermitState, PiesOnHold } from '@/utils/enums/codeEnums';
 import type { Code, Permission } from '../ui';
 
-export type CreateEnquiryResponse = Enquiry & { contact?: Contact };
+export type CreateEnquiryResponse = Enquiry & { contact: Contact };
 
 export interface CreateObjectResponse {
   id: string;

--- a/frontend/src/views/internal/EnquiryView.vue
+++ b/frontend/src/views/internal/EnquiryView.vue
@@ -176,7 +176,7 @@ onBeforeMount(async () => {
       .filter((x) => x.noteHistoryId && x.createdBy);
 
     if (noteHistoryCreatedByUsers.length) {
-      const noteHistoryUsers = await userService.listUsers({
+      const noteHistoryUsers = await userService.searchUsers({
         userId: noteHistoryCreatedByUsers.map((x) => x.createdBy!)
       });
 

--- a/frontend/src/views/internal/ProjectView.vue
+++ b/frontend/src/views/internal/ProjectView.vue
@@ -171,7 +171,7 @@ onBeforeMount(async () => {
       .filter((x) => x.noteHistoryId && x.createdBy);
 
     if (noteHistoryCreatedByUsers.length) {
-      const noteHistoryUsers = await userService.listUsers({
+      const noteHistoryUsers = await userService.searchUsers({
         userId: noteHistoryCreatedByUsers.map((x) => x.createdBy!)
       });
 

--- a/frontend/src/views/internal/UserManagementView.vue
+++ b/frontend/src/views/internal/UserManagementView.vue
@@ -325,7 +325,7 @@ onBeforeMount(async () => {
     const idpCfg = findIdpConfig(IdentityProviderKind.AZUREIDIR);
     if (!idpCfg) throw new Error(`${t('views.i.userManagementView.errorIdpCfg')}`);
 
-    const users: User[] = await userService.listUsers({
+    const users: User[] = await userService.searchUsers({
       active: true,
       idp: [idpCfg.idp],
       includeUserGroups: true,
@@ -357,7 +357,7 @@ onBeforeMount(async () => {
       .filter((x) => x.user.groups.length > 0 || x.accessRequest);
 
     // Get requesting users and add their access requests
-    const newRequestingUsers: User[] = await userService.listUsers({
+    const newRequestingUsers: User[] = await userService.searchUsers({
       userId: Array.from(currentAccessRequests.keys())
     });
 

--- a/frontend/tests/unit/components/authorization/AuthorizationForm.spec.ts
+++ b/frontend/tests/unit/components/authorization/AuthorizationForm.spec.ts
@@ -24,7 +24,7 @@ vi.mock('@/services', () => ({
   permitService: { upsertPermit: vi.fn(), deletePermit: vi.fn() },
   permitNoteService: { createPermitNote: vi.fn() },
   sourceSystemKindService: { listSourceSystemKinds: vi.fn() },
-  userService: { listUsers: vi.fn() }
+  userService: { searchUsers: vi.fn() }
 }));
 
 // Mock PrimeVue Composables
@@ -153,7 +153,7 @@ describe('AuthorizationForm.vue', () => {
     vi.mocked(useConfirm).mockReturnValue({ require: mockConfirmRequire } as any);
 
     vi.mocked(sourceSystemKindService.listSourceSystemKinds).mockResolvedValue(testSourceSystemKinds);
-    vi.mocked(userService.listUsers).mockResolvedValue([{ firstName: 'John', lastName: 'Doe' }] as User[]);
+    vi.mocked(userService.searchUsers).mockResolvedValue([{ firstName: 'John', lastName: 'Doe' }] as User[]);
   });
 
   describe('Initialization and Rendering', () => {
@@ -172,7 +172,7 @@ describe('AuthorizationForm.vue', () => {
       );
       await flushPromises();
 
-      expect(userService.listUsers).toHaveBeenCalledWith({ userId: ['user-1'] });
+      expect(userService.searchUsers).toHaveBeenCalledWith({ userId: ['user-1'] });
       expect(wrapper.html()).toContain('Agency');
       expect(wrapper.html()).toContain('Domain');
       expect(wrapper.html()).toContain('Doe, John');

--- a/frontend/tests/unit/components/authorization/AuthorizationUpdateHistory.spec.ts
+++ b/frontend/tests/unit/components/authorization/AuthorizationUpdateHistory.spec.ts
@@ -11,7 +11,7 @@ import { StorageKey } from '@/utils/enums/application';
 
 import type { User } from '@/types';
 
-const listUsersSpy = vi.spyOn(userService, 'listUsers');
+const listUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({

--- a/frontend/tests/unit/components/authorization/AuthorizationUpdateHistory.spec.ts
+++ b/frontend/tests/unit/components/authorization/AuthorizationUpdateHistory.spec.ts
@@ -11,7 +11,7 @@ import { StorageKey } from '@/utils/enums/application';
 
 import type { User } from '@/types';
 
-const listUsersSpy = vi.spyOn(userService, 'searchUsers');
+const searchUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
@@ -62,7 +62,7 @@ beforeEach(() => {
 
   vi.clearAllMocks();
 
-  listUsersSpy.mockResolvedValue([{ fullName: 'dummyName' }] as User[]);
+  searchUsersSpy.mockResolvedValue([{ fullName: 'dummyName' }] as User[]);
 });
 
 afterEach(() => {

--- a/frontend/tests/unit/components/contact/ContactForm.spec.ts
+++ b/frontend/tests/unit/components/contact/ContactForm.spec.ts
@@ -21,7 +21,7 @@ vi.mock('@/lib/primevue/useToast', () => ({
   })
 }));
 
-const putContactSpy = vi.spyOn(contactService, 'putContact');
+const upsertContactSpy = vi.spyOn(contactService, 'upsertContact');
 
 const testContact: Contact = {
   contactId: 'contact123',
@@ -80,7 +80,7 @@ describe('ContactForm.vue', () => {
 
   describe('onSubmit', () => {
     it('handles successful form submission', async () => {
-      putContactSpy.mockResolvedValueOnce(testContact);
+      upsertContactSpy.mockResolvedValueOnce(testContact);
 
       const wrapper = mount(ContactForm, wrapperSettingsForm(true));
       const vm: any = wrapper.vm; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -88,32 +88,32 @@ describe('ContactForm.vue', () => {
       vm.formRef = { resetForm: vi.fn(), values: {} };
       await vm.onSubmit(testContact);
 
-      expect(putContactSpy).toHaveBeenCalled();
+      expect(upsertContactSpy).toHaveBeenCalled();
       expect(mockToastSuccess).toHaveBeenCalledWith(t('contactForm.formSaved'));
       expect(wrapper.emitted('updateContact')?.[0]).toEqual([testContact]);
     });
 
     it('handles API failure response', async () => {
-      putContactSpy.mockRejectedValueOnce(new Error('Bad Request'));
+      upsertContactSpy.mockRejectedValueOnce(new Error('Bad Request'));
 
       const wrapper = mount(ContactForm, wrapperSettingsForm(true));
       const vm: any = wrapper.vm; // eslint-disable-line @typescript-eslint/no-explicit-any
 
       await vm.onSubmit(testContact);
 
-      expect(putContactSpy).toHaveBeenCalled();
+      expect(upsertContactSpy).toHaveBeenCalled();
       expect(mockToastError).toHaveBeenCalledWith(t('contactForm.failedToSaveTheForm'), 'Error: Bad Request');
     });
 
     it('handles caught exceptions during submission', async () => {
-      putContactSpy.mockRejectedValueOnce(new Error('Network Failure'));
+      upsertContactSpy.mockRejectedValueOnce(new Error('Network Failure'));
 
       const wrapper = mount(ContactForm, wrapperSettingsForm(true));
       const vm: any = wrapper.vm; // eslint-disable-line @typescript-eslint/no-explicit-any
 
       await vm.onSubmit(testContact);
 
-      expect(putContactSpy).toHaveBeenCalled();
+      expect(upsertContactSpy).toHaveBeenCalled();
       expect(mockToastError).toHaveBeenCalledWith(t('contactForm.failedToSaveTheForm'), 'Error: Network Failure');
     });
   });

--- a/frontend/tests/unit/components/contact/ContactPage.spec.ts
+++ b/frontend/tests/unit/components/contact/ContactPage.spec.ts
@@ -39,7 +39,7 @@ const testContact = {
 vi.spyOn(contactService, 'getContact').mockResolvedValue(testContact);
 vi.spyOn(housingProjectService, 'searchProjects').mockResolvedValue([]);
 vi.spyOn(enquiryService, 'searchEnquiries').mockResolvedValue([]);
-vi.spyOn(userService, 'listUsers').mockResolvedValue([]);
+vi.spyOn(userService, 'searchUsers').mockResolvedValue([]);
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/frontend/tests/unit/components/enquiry/EnquiryCard.spec.ts
+++ b/frontend/tests/unit/components/enquiry/EnquiryCard.spec.ts
@@ -12,7 +12,7 @@ import type { Enquiry, User } from '@/types';
 import { projectEnquiryRouteNameKey } from '@/utils/keys';
 import { ref } from 'vue';
 
-const listUsersSpy = vi.spyOn(userService, 'listUsers');
+const listUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 const currentDate = new Date().toISOString();
 

--- a/frontend/tests/unit/components/enquiry/EnquiryCard.spec.ts
+++ b/frontend/tests/unit/components/enquiry/EnquiryCard.spec.ts
@@ -12,7 +12,7 @@ import type { Enquiry, User } from '@/types';
 import { projectEnquiryRouteNameKey } from '@/utils/keys';
 import { ref } from 'vue';
 
-const listUsersSpy = vi.spyOn(userService, 'searchUsers');
+const searchUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 const currentDate = new Date().toISOString();
 
@@ -34,7 +34,7 @@ const testEnquiry: Enquiry = {
   atsEnquiryId: 654321
 };
 
-listUsersSpy.mockResolvedValue([{ fullName: 'dummyName' }] as User[]);
+searchUsersSpy.mockResolvedValue([{ fullName: 'dummyName' }] as User[]);
 
 const wrapperSettings = (testEnquiryProp = testEnquiry) => ({
   props: {

--- a/frontend/tests/unit/components/enquiry/EnquiryForm.spec.ts
+++ b/frontend/tests/unit/components/enquiry/EnquiryForm.spec.ts
@@ -22,7 +22,7 @@ import { PRIMEVUE_STUBS, VEE_FORM_STUB } from '../../../helpers';
 import type { Ref } from 'vue';
 import type { Enquiry, HousingProject, Project, ProjectService, User } from '@/types';
 
-const listUsersSpy = vi.spyOn(userService, 'listUsers');
+const listUsersSpy = vi.spyOn(userService, 'searchUsers');
 const patchEnquirySpy = vi.spyOn(enquiryService, 'patchEnquiry');
 const listHousingActivityIdsSpy = vi.spyOn(housingProjectService, 'listActivityIds');
 const listElectrificationActivityIdsSpy = vi.spyOn(electrificationProjectService, 'listActivityIds');
@@ -113,7 +113,7 @@ const wrapperSettings = (
 describe('EnquiryForm.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(userService.listUsers).mockResolvedValue([{ fullName: 'dummyName' }] as User[]);
+    vi.mocked(userService.searchUsers).mockResolvedValue([{ fullName: 'dummyName' }] as User[]);
     vi.mocked(enquiryService.patchEnquiry).mockResolvedValue({
       enquiryId: 'enquiry123',
       activityId: 'activity456'

--- a/frontend/tests/unit/components/enquiry/EnquiryForm.spec.ts
+++ b/frontend/tests/unit/components/enquiry/EnquiryForm.spec.ts
@@ -22,7 +22,7 @@ import { PRIMEVUE_STUBS, VEE_FORM_STUB } from '../../../helpers';
 import type { Ref } from 'vue';
 import type { Enquiry, HousingProject, Project, ProjectService, User } from '@/types';
 
-const listUsersSpy = vi.spyOn(userService, 'searchUsers');
+const searchUsersSpy = vi.spyOn(userService, 'searchUsers');
 const patchEnquirySpy = vi.spyOn(enquiryService, 'patchEnquiry');
 const listHousingActivityIdsSpy = vi.spyOn(housingProjectService, 'listActivityIds');
 const listElectrificationActivityIdsSpy = vi.spyOn(electrificationProjectService, 'listActivityIds');
@@ -168,8 +168,8 @@ describe('EnquiryForm.vue', () => {
       await flushPromises();
       await nextTick();
 
-      expect(listUsersSpy).toHaveBeenCalledTimes(1);
-      expect(listUsersSpy).toHaveBeenCalledWith({ userId: [mountEnquiry.assignedUserId] });
+      expect(searchUsersSpy).toHaveBeenCalledTimes(1);
+      expect(searchUsersSpy).toHaveBeenCalledWith({ userId: [mountEnquiry.assignedUserId] });
     });
 
     it('gets housing activity Ids onMount', async () => {

--- a/frontend/tests/unit/components/form/section/SubmissionStateSection.spec.ts
+++ b/frontend/tests/unit/components/form/section/SubmissionStateSection.spec.ts
@@ -22,7 +22,7 @@ import type { User } from '@/types';
 
 // Mocks
 
-const listUsersSpy = vi.spyOn(userService, 'searchUsers');
+const searchUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 // Fixtures
 
@@ -71,7 +71,7 @@ function mountSubmissionStateSection(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  listUsersSpy.mockResolvedValue([]);
+  searchUsersSpy.mockResolvedValue([]);
 });
 
 // Tests
@@ -181,7 +181,7 @@ describe('SubmissionStateSection', () => {
 
   describe('assignee loading', () => {
     it('loads the assignee by the project assignedUserId when not an enquiry', async () => {
-      listUsersSpy.mockResolvedValue([{ userId: 'user-1' } as User]);
+      searchUsersSpy.mockResolvedValue([{ userId: 'user-1' } as User]);
 
       mountSubmissionStateSection({
         isEnquiry: false,
@@ -190,7 +190,7 @@ describe('SubmissionStateSection', () => {
       await nextTick();
       await nextTick();
 
-      expect(listUsersSpy).toHaveBeenCalledWith({ userId: ['user-1'] });
+      expect(searchUsersSpy).toHaveBeenCalledWith({ userId: ['user-1'] });
     });
 
     it('loads the assignee by the enquiry assignedUserId when isEnquiry is true', async () => {
@@ -201,7 +201,7 @@ describe('SubmissionStateSection', () => {
       await nextTick();
       await nextTick();
 
-      expect(listUsersSpy).toHaveBeenCalledWith({ userId: ['user-2'] });
+      expect(searchUsersSpy).toHaveBeenCalledWith({ userId: ['user-2'] });
     });
 
     it('does not attempt to load an assignee when there is no assignedUserId', async () => {
@@ -209,7 +209,7 @@ describe('SubmissionStateSection', () => {
       await nextTick();
       await nextTick();
 
-      expect(listUsersSpy).not.toHaveBeenCalled();
+      expect(searchUsersSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/tests/unit/components/form/section/SubmissionStateSection.spec.ts
+++ b/frontend/tests/unit/components/form/section/SubmissionStateSection.spec.ts
@@ -22,7 +22,7 @@ import type { User } from '@/types';
 
 // Mocks
 
-const listUsersSpy = vi.spyOn(userService, 'listUsers');
+const listUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 // Fixtures
 

--- a/frontend/tests/unit/components/general/project/ProjectFormNavigator.spec.ts
+++ b/frontend/tests/unit/components/general/project/ProjectFormNavigator.spec.ts
@@ -23,7 +23,7 @@ import type { GeneralProject, User } from '@/types';
 // Mocks
 
 const getPidsSpy = vi.spyOn(mapService, 'getPids');
-const listUsersSpy = vi.spyOn(userService, 'searchUsers');
+const searchUsersSpy = vi.spyOn(userService, 'searchUsers');
 const patchProjectSpy = vi.spyOn(generalProjectService, 'patchProject');
 
 // Fixtures
@@ -139,7 +139,7 @@ async function submitForm(wrapper: ReturnType<typeof mountProjectFormNavigator>[
 
 beforeEach(() => {
   vi.clearAllMocks();
-  listUsersSpy.mockResolvedValue([{ fullName: 'dummyName' } as User]);
+  searchUsersSpy.mockResolvedValue([{ fullName: 'dummyName' } as User]);
   getPidsSpy.mockResolvedValue('123456789');
 });
 
@@ -162,7 +162,7 @@ describe('ProjectFormNavigator', () => {
       await flushPromises();
 
       expect(wrapper.isVisible()).toBe(true);
-      expect(listUsersSpy).toHaveBeenCalledExactlyOnceWith({ userId: [mountProject.assignedUserId] });
+      expect(searchUsersSpy).toHaveBeenCalledExactlyOnceWith({ userId: [mountProject.assignedUserId] });
     });
 
     it('gets the location PIDs for the project', async () => {

--- a/frontend/tests/unit/components/general/project/ProjectFormNavigator.spec.ts
+++ b/frontend/tests/unit/components/general/project/ProjectFormNavigator.spec.ts
@@ -23,7 +23,7 @@ import type { GeneralProject, User } from '@/types';
 // Mocks
 
 const getPidsSpy = vi.spyOn(mapService, 'getPids');
-const listUsersSpy = vi.spyOn(userService, 'listUsers');
+const listUsersSpy = vi.spyOn(userService, 'searchUsers');
 const patchProjectSpy = vi.spyOn(generalProjectService, 'patchProject');
 
 // Fixtures

--- a/frontend/tests/unit/components/housing/project/ProjectFormNavigator.spec.ts
+++ b/frontend/tests/unit/components/housing/project/ProjectFormNavigator.spec.ts
@@ -25,7 +25,7 @@ import type { AtsClientResource, AtsEnquiryResource, Group, HousingProject, User
 const createAtsClientSpy = vi.spyOn(atsService, 'createAtsClient');
 const createAtsEnquirySpy = vi.spyOn(atsService, 'createAtsEnquiry');
 const getPidsSpy = vi.spyOn(mapService, 'getPids');
-const listUsersSpy = vi.spyOn(userService, 'searchUsers');
+const searchUsersSpy = vi.spyOn(userService, 'searchUsers');
 const patchProjectSpy = vi.spyOn(housingProjectService, 'patchProject');
 
 // Fixtures
@@ -177,7 +177,7 @@ async function submitForm(wrapper: ReturnType<typeof mountProjectFormNavigator>[
 
 beforeEach(() => {
   vi.clearAllMocks();
-  listUsersSpy.mockResolvedValue([{ fullName: 'dummyName' } as User]);
+  searchUsersSpy.mockResolvedValue([{ fullName: 'dummyName' } as User]);
   getPidsSpy.mockResolvedValue('123456789');
 });
 
@@ -200,7 +200,7 @@ describe('ProjectFormNavigator', () => {
       await flushPromises();
 
       expect(wrapper.isVisible()).toBe(true);
-      expect(listUsersSpy).toHaveBeenCalledExactlyOnceWith({ userId: [mountProject.assignedUserId] });
+      expect(searchUsersSpy).toHaveBeenCalledExactlyOnceWith({ userId: [mountProject.assignedUserId] });
     });
 
     it('gets the location PIDs for the project', async () => {

--- a/frontend/tests/unit/components/housing/project/ProjectFormNavigator.spec.ts
+++ b/frontend/tests/unit/components/housing/project/ProjectFormNavigator.spec.ts
@@ -25,7 +25,7 @@ import type { AtsClientResource, AtsEnquiryResource, Group, HousingProject, User
 const createAtsClientSpy = vi.spyOn(atsService, 'createAtsClient');
 const createAtsEnquirySpy = vi.spyOn(atsService, 'createAtsEnquiry');
 const getPidsSpy = vi.spyOn(mapService, 'getPids');
-const listUsersSpy = vi.spyOn(userService, 'listUsers');
+const listUsersSpy = vi.spyOn(userService, 'searchUsers');
 const patchProjectSpy = vi.spyOn(housingProjectService, 'patchProject');
 
 // Fixtures

--- a/frontend/tests/unit/components/note/NoteForm.spec.ts
+++ b/frontend/tests/unit/components/note/NoteForm.spec.ts
@@ -27,7 +27,7 @@ vi.mock('vue-router', () => ({
   })
 }));
 
-const listUsersSpy = vi.spyOn(userService, 'listUsers');
+const listUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 const TEST_NOTE: Note = {
   noteId: '123',

--- a/frontend/tests/unit/components/note/NoteForm.spec.ts
+++ b/frontend/tests/unit/components/note/NoteForm.spec.ts
@@ -27,7 +27,7 @@ vi.mock('vue-router', () => ({
   })
 }));
 
-const listUsersSpy = vi.spyOn(userService, 'searchUsers');
+const searchUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 const TEST_NOTE: Note = {
   noteId: '123',
@@ -108,7 +108,7 @@ afterEach(() => {
 // Currently, modal functionality hidden behind Primevue component Dialog
 describe('NoteForm', () => {
   it('renders', () => {
-    listUsersSpy.mockResolvedValue([{ fullName: 'dummyName' }] as User[]);
+    searchUsersSpy.mockResolvedValue([{ fullName: 'dummyName' }] as User[]);
     const wrapper = shallowMount(NoteForm, wrapperSettings());
     expect(wrapper).toBeTruthy();
   });

--- a/frontend/tests/unit/components/note/NoteHistoryCard.spec.ts
+++ b/frontend/tests/unit/components/note/NoteHistoryCard.spec.ts
@@ -15,7 +15,7 @@ import type { Note, NoteHistory, User } from '@/types';
 
 const { t } = useI18n();
 
-const listUsersSpy = vi.spyOn(userService, 'listUsers');
+const listUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({

--- a/frontend/tests/unit/components/note/NoteHistoryCard.spec.ts
+++ b/frontend/tests/unit/components/note/NoteHistoryCard.spec.ts
@@ -15,7 +15,7 @@ import type { Note, NoteHistory, User } from '@/types';
 
 const { t } = useI18n();
 
-const listUsersSpy = vi.spyOn(userService, 'searchUsers');
+const searchUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({
@@ -118,7 +118,7 @@ beforeEach(() => {
 
   vi.clearAllMocks();
 
-  listUsersSpy.mockResolvedValue([{ fullName: 'dummyName' }] as User[]);
+  searchUsersSpy.mockResolvedValue([{ fullName: 'dummyName' }] as User[]);
 });
 
 afterEach(() => {
@@ -145,7 +145,7 @@ describe('NoteHistoryCard', () => {
         stubs: ['font-awesome-icon']
       }
     });
-    expect(listUsersSpy).not.toHaveBeenCalled();
+    expect(searchUsersSpy).not.toHaveBeenCalled();
     expect(wrapper.get('h3').text()).toBe(TEST_NOTE_HISTORY.title);
   });
 

--- a/frontend/tests/unit/components/projectCommon/ProjectRoadmapTab.spec.ts
+++ b/frontend/tests/unit/components/projectCommon/ProjectRoadmapTab.spec.ts
@@ -9,13 +9,13 @@ import { roadmapService, userService } from '@/services';
 
 vi.mock('@/services', () => ({
   roadmapService: { getRoadmapNote: vi.fn(), sendRoadmap: vi.fn() },
-  userService: { listUsers: vi.fn() }
+  userService: { searchUsers: vi.fn() }
 }));
 
 describe('ProjectRoadmapTab.vue', () => {
   it('initializes BCC with multiple emails from config and assignee', async () => {
     vi.mocked(roadmapService.getRoadmapNote).mockResolvedValue('Roadmap note');
-    vi.mocked(userService.listUsers).mockResolvedValue([
+    vi.mocked(userService.searchUsers).mockResolvedValue([
       {
         userId: 'user1',
         email: 'navigator@bcgov.bc.ca',

--- a/frontend/tests/unit/components/projectCommon/ProjectTeamTab.spec.ts
+++ b/frontend/tests/unit/components/projectCommon/ProjectTeamTab.spec.ts
@@ -32,7 +32,7 @@ vi.mock('@/services', () => ({
     deleteActivityContact: vi.fn()
   },
   contactService: {
-    putContact: vi.fn()
+    upsertContact: vi.fn()
   }
 }));
 
@@ -161,7 +161,7 @@ describe('ProjectTeamTab.vue', () => {
     });
 
     it('handles single success toast for PRIMARY role', async () => {
-      vi.mocked(contactService.putContact).mockResolvedValue(mockContact);
+      vi.mocked(contactService.upsertContact).mockResolvedValue(mockContact);
       vi.mocked(activityContactService.createActivityContact).mockResolvedValue(mockActivityContact);
 
       const wrapper = shallowMount(ProjectTeamTab, wrapperSettings());
@@ -251,7 +251,7 @@ describe('ProjectTeamTab.vue', () => {
     });
 
     it('calls updateContact when contactId is missing (manual entry)', async () => {
-      vi.mocked(contactService.putContact).mockResolvedValue(mockContact);
+      vi.mocked(contactService.upsertContact).mockResolvedValue(mockContact);
       vi.mocked(activityContactService.createActivityContact).mockResolvedValue(mockActivityContact);
 
       const wrapper = shallowMount(ProjectTeamTab, wrapperSettings());
@@ -262,12 +262,12 @@ describe('ProjectTeamTab.vue', () => {
       ]);
       await flushPromises();
 
-      expect(contactService.putContact).toHaveBeenCalled();
+      expect(contactService.upsertContact).toHaveBeenCalled();
       expect(activityContactService.createActivityContact).toHaveBeenCalled();
     });
 
     it('covers single success toast for ADMIN role', async () => {
-      vi.mocked(contactService.putContact).mockResolvedValue(mockContact);
+      vi.mocked(contactService.upsertContact).mockResolvedValue(mockContact);
       vi.mocked(activityContactService.createActivityContact).mockResolvedValue(mockActivityContact);
 
       const wrapper = shallowMount(ProjectTeamTab, wrapperSettings());
@@ -282,7 +282,7 @@ describe('ProjectTeamTab.vue', () => {
     });
 
     it('covers single success toast for MEMBER role', async () => {
-      vi.mocked(contactService.putContact).mockResolvedValue(mockContact);
+      vi.mocked(contactService.upsertContact).mockResolvedValue(mockContact);
       vi.mocked(activityContactService.createActivityContact).mockResolvedValue(mockActivityContact);
 
       const wrapper = shallowMount(ProjectTeamTab, wrapperSettings());

--- a/frontend/tests/unit/composables/useUserSearch.spec.ts
+++ b/frontend/tests/unit/composables/useUserSearch.spec.ts
@@ -9,7 +9,7 @@ import type { User } from '@/types';
 
 // Mocks
 
-const listUsersSpy = vi.spyOn(userService, 'listUsers');
+const listUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 // Fixtures
 

--- a/frontend/tests/unit/composables/useUserSearch.spec.ts
+++ b/frontend/tests/unit/composables/useUserSearch.spec.ts
@@ -9,7 +9,7 @@ import type { User } from '@/types';
 
 // Mocks
 
-const listUsersSpy = vi.spyOn(userService, 'searchUsers');
+const searchUsersSpy = vi.spyOn(userService, 'searchUsers');
 
 // Fixtures
 
@@ -22,7 +22,7 @@ function setIdpList(idpList: unknown[]) {
 beforeEach(() => {
   vi.clearAllMocks();
   setActivePinia(createPinia());
-  listUsersSpy.mockResolvedValue([]);
+  searchUsersSpy.mockResolvedValue([]);
 });
 
 // Tests
@@ -35,17 +35,17 @@ describe('useUserSearch', () => {
       const { loadById } = useUserSearch();
       await loadById('user-1');
 
-      expect(listUsersSpy).not.toHaveBeenCalled();
+      expect(searchUsersSpy).not.toHaveBeenCalled();
     });
 
     it('wraps a single userId in an array and populates users', async () => {
       setIdpList([azureIdp]);
-      listUsersSpy.mockResolvedValue([{ userId: 'user-1' } as User]);
+      searchUsersSpy.mockResolvedValue([{ userId: 'user-1' } as User]);
 
       const { loadById, users } = useUserSearch();
       await loadById('user-1');
 
-      expect(listUsersSpy).toHaveBeenCalledWith({ userId: ['user-1'] });
+      expect(searchUsersSpy).toHaveBeenCalledWith({ userId: ['user-1'] });
       expect(users.value).toEqual([{ userId: 'user-1' }]);
     });
 
@@ -55,7 +55,7 @@ describe('useUserSearch', () => {
       const { loadById } = useUserSearch();
       await loadById(['user-1', 'user-2']);
 
-      expect(listUsersSpy).toHaveBeenCalledWith({ userId: ['user-1', 'user-2'] });
+      expect(searchUsersSpy).toHaveBeenCalledWith({ userId: ['user-1', 'user-2'] });
     });
   });
 
@@ -66,7 +66,7 @@ describe('useUserSearch', () => {
       const { search } = useUserSearch();
       await search('someone@example.com');
 
-      expect(listUsersSpy).not.toHaveBeenCalled();
+      expect(searchUsersSpy).not.toHaveBeenCalled();
     });
 
     it('searches by email and fullName when the input meets the minimum length', async () => {
@@ -75,7 +75,7 @@ describe('useUserSearch', () => {
       const { search } = useUserSearch();
       await search('jo');
 
-      expect(listUsersSpy).toHaveBeenCalledWith({ email: 'jo', fullName: 'jo', idp: ['azureidir'] });
+      expect(searchUsersSpy).toHaveBeenCalledWith({ email: 'jo', fullName: 'jo', idp: ['azureidir'] });
     });
 
     // MIN_SEARCH_INPUT_LENGTH is 2, and a valid email always has at least 2
@@ -87,7 +87,7 @@ describe('useUserSearch', () => {
       const { search } = useUserSearch();
       await search('a@b.co');
 
-      expect(listUsersSpy).toHaveBeenCalledWith({ email: 'a@b.co', fullName: 'a@b.co', idp: ['azureidir'] });
+      expect(searchUsersSpy).toHaveBeenCalledWith({ email: 'a@b.co', fullName: 'a@b.co', idp: ['azureidir'] });
     });
 
     it('clears users when the input is too short and not an email', async () => {
@@ -97,7 +97,7 @@ describe('useUserSearch', () => {
       users.value = [{ userId: 'stale' } as User];
       await search('a');
 
-      expect(listUsersSpy).not.toHaveBeenCalled();
+      expect(searchUsersSpy).not.toHaveBeenCalled();
       expect(users.value).toEqual([]);
     });
   });

--- a/frontend/tests/unit/service/contactService.spec.ts
+++ b/frontend/tests/unit/service/contactService.spec.ts
@@ -5,7 +5,7 @@ import {
   deleteContact,
   matchContacts,
   searchContacts,
-  putContact
+  upsertContact
 } from '@/services/contactService';
 import { appAxios } from '@/services/interceptors';
 
@@ -16,7 +16,6 @@ vi.mock('@/services/interceptors', () => ({
 describe('contactService', () => {
   const mockGet = vi.fn();
   const mockPost = vi.fn();
-  const mockPut = vi.fn();
   const mockDelete = vi.fn();
 
   beforeEach(() => {
@@ -25,7 +24,6 @@ describe('contactService', () => {
     vi.mocked(appAxios).mockReturnValue({
       get: mockGet,
       post: mockPost,
-      put: mockPut,
       delete: mockDelete
     } as never);
   });
@@ -189,8 +187,8 @@ describe('contactService', () => {
     });
   });
 
-  describe('putContact', () => {
-    it('updates a contact and returns the updated resource', async () => {
+  describe('upsertContact', () => {
+    it('saves a contact and returns the saved resource', async () => {
       const request = {
         firstName: 'Jane',
         lastName: 'Doe'
@@ -201,13 +199,13 @@ describe('contactService', () => {
         ...request
       };
 
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: contact
       });
 
-      const result = await putContact(request as never);
+      const result = await upsertContact(request as never);
 
-      expect(mockPut).toHaveBeenCalledWith('contact', request, undefined);
+      expect(mockPost).toHaveBeenCalledWith('contact', request, undefined);
 
       expect(result).toEqual(contact);
     });
@@ -215,9 +213,9 @@ describe('contactService', () => {
     it('propagates errors', async () => {
       const error = new Error('update failed');
 
-      mockPut.mockRejectedValue(error);
+      mockPost.mockRejectedValue(error);
 
-      await expect(putContact({} as never)).rejects.toThrow(error);
+      await expect(upsertContact({} as never)).rejects.toThrow(error);
     });
   });
 
@@ -228,7 +226,7 @@ describe('contactService', () => {
       deleteContact,
       matchContacts,
       searchContacts,
-      putContact
+      upsertContact
     });
   });
 });

--- a/frontend/tests/unit/service/electrificationProjectService.spec.ts
+++ b/frontend/tests/unit/service/electrificationProjectService.spec.ts
@@ -24,7 +24,6 @@ vi.mock('@/services/interceptors', () => ({
 describe('electrificationProject service', () => {
   const mockGet = vi.fn();
   const mockPost = vi.fn();
-  const mockPut = vi.fn();
   const mockPatch = vi.fn();
   const mockDelete = vi.fn();
 
@@ -36,7 +35,6 @@ describe('electrificationProject service', () => {
     vi.mocked(appAxios).mockReturnValue({
       get: mockGet,
       post: mockPost,
-      put: mockPut,
       patch: mockPatch,
       delete: mockDelete
     } as never);
@@ -256,19 +254,19 @@ describe('electrificationProject service', () => {
         projectId: 'project-1'
       };
 
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: project
       });
 
       const result = await submitDraft(request as never);
 
-      expect(mockPut).toHaveBeenCalledWith(`${PATH}/draft/submit`, request, undefined);
+      expect(mockPost).toHaveBeenCalledWith(`${PATH}/draft/submit`, request, undefined);
 
       expect(result).toEqual(project);
     });
 
     it('propagates errors', async () => {
-      mockPut.mockRejectedValue(new Error('failed'));
+      mockPost.mockRejectedValue(new Error('failed'));
 
       await expect(submitDraft({} as never)).rejects.toThrow('failed');
     });
@@ -346,19 +344,19 @@ describe('electrificationProject service', () => {
         draftId: 'draft-1'
       };
 
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: draft
       });
 
       const result = await upsertDraft(draft as never);
 
-      expect(mockPut).toHaveBeenCalledWith(`${PATH}/draft`, draft, undefined);
+      expect(mockPost).toHaveBeenCalledWith(`${PATH}/draft`, draft, undefined);
 
       expect(result).toEqual(draft);
     });
 
     it('propagates errors', async () => {
-      mockPut.mockRejectedValue(new Error('failed'));
+      mockPost.mockRejectedValue(new Error('failed'));
 
       await expect(upsertDraft({} as never)).rejects.toThrow('failed');
     });

--- a/frontend/tests/unit/service/generalProjectService.spec.ts
+++ b/frontend/tests/unit/service/generalProjectService.spec.ts
@@ -24,7 +24,6 @@ vi.mock('@/services/interceptors', () => ({
 describe('generalProject service', () => {
   const mockGet = vi.fn();
   const mockPost = vi.fn();
-  const mockPut = vi.fn();
   const mockPatch = vi.fn();
   const mockDelete = vi.fn();
 
@@ -36,7 +35,6 @@ describe('generalProject service', () => {
     vi.mocked(appAxios).mockReturnValue({
       get: mockGet,
       post: mockPost,
-      put: mockPut,
       patch: mockPatch,
       delete: mockDelete
     } as never);
@@ -256,19 +254,19 @@ describe('generalProject service', () => {
         projectId: 'project-1'
       };
 
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: project
       });
 
       const result = await submitDraft(request as never);
 
-      expect(mockPut).toHaveBeenCalledWith(`${PATH}/draft/submit`, request, undefined);
+      expect(mockPost).toHaveBeenCalledWith(`${PATH}/draft/submit`, request, undefined);
 
       expect(result).toEqual(project);
     });
 
     it('propagates errors', async () => {
-      mockPut.mockRejectedValue(new Error('failed'));
+      mockPost.mockRejectedValue(new Error('failed'));
 
       await expect(submitDraft({} as never)).rejects.toThrow('failed');
     });
@@ -346,19 +344,19 @@ describe('generalProject service', () => {
         draftId: 'draft-1'
       };
 
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: draft
       });
 
       const result = await upsertDraft(draft as never);
 
-      expect(mockPut).toHaveBeenCalledWith(`${PATH}/draft`, draft, undefined);
+      expect(mockPost).toHaveBeenCalledWith(`${PATH}/draft`, draft, undefined);
 
       expect(result).toEqual(draft);
     });
 
     it('propagates errors', async () => {
-      mockPut.mockRejectedValue(new Error('failed'));
+      mockPost.mockRejectedValue(new Error('failed'));
 
       await expect(upsertDraft({} as never)).rejects.toThrow('failed');
     });

--- a/frontend/tests/unit/service/housingProjectService.spec.ts
+++ b/frontend/tests/unit/service/housingProjectService.spec.ts
@@ -24,7 +24,6 @@ vi.mock('@/services/interceptors', () => ({
 describe('housingProject service', () => {
   const mockGet = vi.fn();
   const mockPost = vi.fn();
-  const mockPut = vi.fn();
   const mockPatch = vi.fn();
   const mockDelete = vi.fn();
 
@@ -36,7 +35,6 @@ describe('housingProject service', () => {
     vi.mocked(appAxios).mockReturnValue({
       get: mockGet,
       post: mockPost,
-      put: mockPut,
       patch: mockPatch,
       delete: mockDelete
     } as never);
@@ -250,19 +248,19 @@ describe('housingProject service', () => {
         projectId: 'project-1'
       };
 
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: project
       });
 
       const result = await submitDraft(request as never);
 
-      expect(mockPut).toHaveBeenCalledWith(`${PATH}/draft/submit`, request, undefined);
+      expect(mockPost).toHaveBeenCalledWith(`${PATH}/draft/submit`, request, undefined);
 
       expect(result).toEqual(project);
     });
 
     it('propagates errors', async () => {
-      mockPut.mockRejectedValue(new Error('failed'));
+      mockPost.mockRejectedValue(new Error('failed'));
 
       await expect(submitDraft({} as never)).rejects.toThrow('failed');
     });
@@ -334,19 +332,19 @@ describe('housingProject service', () => {
         draftId: 'draft-1'
       };
 
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: draft
       });
 
       const result = await upsertDraft(draft as never);
 
-      expect(mockPut).toHaveBeenCalledWith(`${PATH}/draft`, draft, undefined);
+      expect(mockPost).toHaveBeenCalledWith(`${PATH}/draft`, draft, undefined);
 
       expect(result).toEqual(draft);
     });
 
     it('propagates errors', async () => {
-      mockPut.mockRejectedValue(new Error('failed'));
+      mockPost.mockRejectedValue(new Error('failed'));
 
       await expect(upsertDraft({} as never)).rejects.toThrow('failed');
     });

--- a/frontend/tests/unit/service/noteHistoryService.spec.ts
+++ b/frontend/tests/unit/service/noteHistoryService.spec.ts
@@ -4,7 +4,7 @@ import {
   deleteNoteHistory,
   listBringForwards,
   listNoteHistories,
-  putNoteHistory
+  patchNoteHistory
 } from '@/services/noteHistoryService';
 
 import { appAxios } from '@/services/interceptors';
@@ -22,7 +22,7 @@ vi.mock('@/store', () => ({
 describe('noteHistory service', () => {
   const mockPost = vi.fn();
   const mockGet = vi.fn();
-  const mockPut = vi.fn();
+  const mockPatch = vi.fn();
   const mockDelete = vi.fn();
 
   beforeEach(() => {
@@ -35,7 +35,7 @@ describe('noteHistory service', () => {
     vi.mocked(appAxios).mockReturnValue({
       post: mockPost,
       get: mockGet,
-      put: mockPut,
+      patch: mockPatch,
       delete: mockDelete
     } as never);
   });
@@ -167,8 +167,8 @@ describe('noteHistory service', () => {
     });
   });
 
-  describe('putNoteHistory', () => {
-    it('updates a note history record and returns data', async () => {
+  describe('patchNoteHistory', () => {
+    it('patches a note history record and returns data', async () => {
       const request = {
         noteHistoryId: 'note-history-1',
         note: 'Updated note',
@@ -180,13 +180,13 @@ describe('noteHistory service', () => {
         note: 'Updated note'
       };
 
-      mockPut.mockResolvedValue({
+      mockPatch.mockResolvedValue({
         data: response
       });
 
-      const result = await putNoteHistory(request as never);
+      const result = await patchNoteHistory(request as never);
 
-      expect(mockPut).toHaveBeenCalledWith(
+      expect(mockPatch).toHaveBeenCalledWith(
         'housing/note/note-history-1',
         {
           note: 'Updated note',
@@ -201,10 +201,10 @@ describe('noteHistory service', () => {
     it('propagates errors', async () => {
       const error = new Error('update failed');
 
-      mockPut.mockRejectedValue(error);
+      mockPatch.mockRejectedValue(error);
 
       await expect(
-        putNoteHistory({
+        patchNoteHistory({
           noteHistoryId: 'note-history-1'
         } as never)
       ).rejects.toThrow(error);
@@ -217,7 +217,7 @@ describe('noteHistory service', () => {
       deleteNoteHistory,
       listBringForwards,
       listNoteHistories,
-      putNoteHistory
+      patchNoteHistory
     });
   });
 });

--- a/frontend/tests/unit/service/permitService.spec.ts
+++ b/frontend/tests/unit/service/permitService.spec.ts
@@ -22,7 +22,6 @@ vi.mock('@/store', () => ({
 describe('permit service', () => {
   const mockGet = vi.fn();
   const mockPost = vi.fn();
-  const mockPut = vi.fn();
   const mockDelete = vi.fn();
 
   beforeEach(() => {
@@ -35,7 +34,6 @@ describe('permit service', () => {
     vi.mocked(appAxios).mockReturnValue({
       get: mockGet,
       post: mockPost,
-      put: mockPut,
       delete: mockDelete
     } as never);
   });
@@ -208,19 +206,19 @@ describe('permit service', () => {
   });
 
   describe('upsertPermit', () => {
-    it('puts permit and returns response data', async () => {
+    it('posts permit and returns response data', async () => {
       const permit = {
         permitId: 'permit-123',
         permitNumber: 'P-001'
       };
 
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: permit
       });
 
       const result = await upsertPermit(permit as never);
 
-      expect(mockPut).toHaveBeenCalledWith('housing/permit', permit, undefined);
+      expect(mockPost).toHaveBeenCalledWith('housing/permit', permit, undefined);
 
       expect(result).toEqual(permit);
     });
@@ -228,7 +226,7 @@ describe('permit service', () => {
     it('propagates errors', async () => {
       const error = new Error('upsert failed');
 
-      mockPut.mockRejectedValue(error);
+      mockPost.mockRejectedValue(error);
 
       await expect(upsertPermit({} as never)).rejects.toThrow(error);
     });

--- a/frontend/tests/unit/service/roadmapService.spec.ts
+++ b/frontend/tests/unit/service/roadmapService.spec.ts
@@ -13,7 +13,7 @@ vi.mock('@/store', () => ({
 }));
 
 describe('roadmap service', () => {
-  const mockPut = vi.fn();
+  const mockPost = vi.fn();
   const mockGet = vi.fn();
 
   beforeEach(() => {
@@ -24,7 +24,7 @@ describe('roadmap service', () => {
     } as never);
 
     vi.mocked(appAxios).mockReturnValue({
-      put: mockPut,
+      post: mockPost,
       get: mockGet
     } as never);
   });
@@ -35,7 +35,7 @@ describe('roadmap service', () => {
         success: true
       };
 
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: response
       });
 
@@ -50,7 +50,7 @@ describe('roadmap service', () => {
         }
       } as never);
 
-      expect(mockPut).toHaveBeenCalledWith(
+      expect(mockPost).toHaveBeenCalledWith(
         'housing/roadmap',
         {
           activityId: 'activity-1',
@@ -69,7 +69,7 @@ describe('roadmap service', () => {
     });
 
     it('normalizes string email fields', async () => {
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: {}
       });
 
@@ -83,7 +83,7 @@ describe('roadmap service', () => {
         }
       } as never);
 
-      expect(mockPut).toHaveBeenCalledWith(
+      expect(mockPost).toHaveBeenCalledWith(
         'housing/roadmap',
         {
           activityId: 'activity-1',
@@ -99,7 +99,7 @@ describe('roadmap service', () => {
     });
 
     it('splits multiple email addresses', async () => {
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: {}
       });
 
@@ -111,7 +111,7 @@ describe('roadmap service', () => {
         }
       } as never);
 
-      expect(mockPut).toHaveBeenCalledWith(
+      expect(mockPost).toHaveBeenCalledWith(
         'housing/roadmap',
         {
           activityId: 'activity-1',
@@ -126,7 +126,7 @@ describe('roadmap service', () => {
     });
 
     it('defaults cc to an empty array when not supplied', async () => {
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: {}
       });
 
@@ -138,7 +138,7 @@ describe('roadmap service', () => {
         }
       } as never);
 
-      expect(mockPut).toHaveBeenCalledWith(
+      expect(mockPost).toHaveBeenCalledWith(
         'housing/roadmap',
         {
           activityId: 'activity-1',
@@ -153,7 +153,7 @@ describe('roadmap service', () => {
     });
 
     it('does not modify array email fields', async () => {
-      mockPut.mockResolvedValue({
+      mockPost.mockResolvedValue({
         data: {}
       });
 
@@ -167,7 +167,7 @@ describe('roadmap service', () => {
         }
       } as never);
 
-      expect(mockPut).toHaveBeenCalledWith(
+      expect(mockPost).toHaveBeenCalledWith(
         'housing/roadmap',
         {
           activityId: 'activity-1',
@@ -185,7 +185,7 @@ describe('roadmap service', () => {
     it('propagates errors', async () => {
       const error = new Error('send failed');
 
-      mockPut.mockRejectedValue(error);
+      mockPost.mockRejectedValue(error);
 
       await expect(
         sendRoadmap({

--- a/frontend/tests/unit/service/userService.spec.ts
+++ b/frontend/tests/unit/service/userService.spec.ts
@@ -1,5 +1,5 @@
 import { appAxios } from '@/services/interceptors';
-import { listUsers, userService } from '@/services/userService';
+import { searchUsers, userService } from '@/services/userService';
 
 vi.mock('@/services/interceptors', () => ({
   appAxios: vi.fn()
@@ -16,7 +16,7 @@ describe('user service', () => {
     } as never);
   });
 
-  describe('listUsers', () => {
+  describe('searchUsers', () => {
     it('posts search criteria and returns users', async () => {
       const filters = {
         userId: ['user-1']
@@ -37,9 +37,9 @@ describe('user service', () => {
         data: users
       });
 
-      const result = await listUsers(filters as never);
+      const result = await searchUsers(filters as never);
 
-      expect(mockPost).toHaveBeenCalledWith('user', filters, undefined);
+      expect(mockPost).toHaveBeenCalledWith('user/search', filters, undefined);
       expect(result).toEqual(users);
     });
 
@@ -48,9 +48,9 @@ describe('user service', () => {
         data: []
       });
 
-      const result = await listUsers({} as never);
+      const result = await searchUsers({} as never);
 
-      expect(mockPost).toHaveBeenCalledWith('user', {}, undefined);
+      expect(mockPost).toHaveBeenCalledWith('user/search', {}, undefined);
       expect(result).toEqual([]);
     });
 
@@ -59,13 +59,13 @@ describe('user service', () => {
 
       mockPost.mockRejectedValue(error);
 
-      await expect(listUsers({} as never)).rejects.toThrow(error);
+      await expect(searchUsers({} as never)).rejects.toThrow(error);
     });
   });
 
   it('exports all service functions', () => {
     expect(userService).toEqual({
-      listUsers
+      searchUsers
     });
   });
 });

--- a/frontend/tests/unit/views/internal/EnquiryView.spec.ts
+++ b/frontend/tests/unit/views/internal/EnquiryView.spec.ts
@@ -55,7 +55,7 @@ vi.mock('@/services/noteHistoryService', () => ({
 
 vi.mock('@/services/userService', () => ({
   userService: {
-    listUsers: vi.fn()
+    searchUsers: vi.fn()
   }
 }));
 
@@ -97,7 +97,7 @@ beforeEach(() => {
   vi.mocked(noteHistoryService.listNoteHistories).mockResolvedValue([
     { noteHistoryId: '1', createdBy: '123' }
   ] as NoteHistory[]);
-  vi.mocked(userService.listUsers).mockResolvedValue([{ userId: '123', fullName: 'Fake User' }] as User[]);
+  vi.mocked(userService.searchUsers).mockResolvedValue([{ userId: '123', fullName: 'Fake User' }] as User[]);
 });
 
 afterEach(() => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Audited every endpoint across the API for correct HTTP verb usage — PUT vs PATCH vs POST — and fixed the mismatches found:

- Converted several endpoints that were PUT but were actually non-idempotent create-or-update operations with server-generated identifiers (project drafts, permit, contact, roadmap) to POST.
- Converted the note history, project, and enquiry update endpoints from full-replace PUT to partial PATCH, since they only ever update a subset of fields. Moved request destructuring into controllers and narrowed service signatures to take only the fields they actually use, rather than the raw HTTP request DTO.
- Fixed a real bug: `PatchNoteHistoryRequest` allowed `activityId` in the body, letting a client re-parent a note history onto a different activity via PATCH. `activityId` is now `immutable` on the schema and stripped from the Joi validator; the frontend form no longer sends it.
- Dropped the redundant `id` field from the backend `PatchRequestDTO` — every patch endpoint's resource id comes from the route param, never the body, and every caller was destructuring and discarding it. (Frontend keeps it; its service functions take a single request object and need the id to build the URL.)
- Renamed several types for accuracy: `List*ProjectRequest` → `Search*ProjectRequest` (only ever fed the search endpoint), `ListUsersRequest`/`listUsers` → `SearchUsersRequest`/`searchUsers`, `PutContactRequest` → `UpsertContactRequest`.
- Moved `POST /user` to `POST /user/search`, matching every other resource's list-vs-search routing convention.
- Fixed a modeling bug in `EnquiryRelations` (frontend): `contact` was declared as a Prisma relation of `Enquiry`, but Prisma only has `user`/`activity` relations there. Added a proper `CreateEnquiryResponse` type (backend and frontend) for the `contact` field `createEnquiryService` bolts onto its response, replacing a stale `Promise<Enquiry>` return-type annotation.
- Synced the OpenAPI spec with reality: 8 search endpoints (contact, enquiry, and project search across electrification/general/housing, plus user) were documented as `GET` with query params while actually implemented as `POST` with a body — spec now matches. Also filled in previously-undocumented `permit`/`contact` upsert paths. Left the two permit-search endpoints as `GET`, since those genuinely are implemented that way.

https://apps.nrs.gov.bc.ca/int/jira/browse/PADS-812

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

 Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This is a verb/type-correctness pass, not a feature change — no new endpoints, no behavior change for callers already using the correct verb. Frontend has been updated to match everywhere in this repo. OpenAPI spec changes are documentation-only (backend implementation already used POST for the endpoints that were mis-documented as GET).

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->